### PR TITLE
Syntax tree

### DIFF
--- a/ttcn3/syntax/ast.go
+++ b/ttcn3/syntax/ast.go
@@ -1,178 +1,54 @@
 package syntax
 
-import (
-	"strings"
-)
-
 // ----------------------------------------------------------------------------
 // Interfaces
 //
-// There are 3 main classes of nodes: Expressions and type nodes,
-// statement nodes, and declaration nodes. The node names usually
-// match the corresponding Go spec production names to which they
-// correspond. The node fields correspond to the individual parts
-// of the respective productions.
-//
-// All nodes contain position information marking the beginning of
-// the corresponding source text segment; it is accessible via the
-// Pos accessor method. Nodes may contain additional position info
-// for language constructs where comments may be found between parts
-// of the construct (typically any larger, parenthesized subpart).
-// That position information is needed to properly position comments
-// when printing the construct.
 
 // All node types implement the Node interface.
 type Node interface {
-	Pos() Pos // position of first character belonging to the node
-	End() Pos // position of first character immediately after the node
 }
 
 // All expression nodes implement the Expr interface.
 type Expr interface {
 	Node
-	exprNode()
 }
 
 // All statement nodes implement the Stmt interface.
 type Stmt interface {
 	Node
-	stmtNode()
 }
 
 // All declaration nodes implement the Decl interface.
 type Decl interface {
 	Node
-	declNode()
+}
+
+// All node types implement the Node interface.
+type Type interface {
+	Node
 }
 
 // ----------------------------------------------------------------------------
-// Comments
-
-// A Comment node represents a single //-style or /*-style comment.
-type Comment struct {
-	Slash Pos    // position of "/" starting the comment
-	Text  string // comment text (excluding '\n' for //-style comments)
-}
-
-func (c *Comment) Pos() Pos { return c.Slash }
-func (c *Comment) End() Pos { return Pos(int(c.Slash) + len(c.Text)) }
-
-// A CommentGroup represents a sequence of comments
-// with no other tokens and no empty lines between.
-//
-type CommentGroup struct {
-	List []*Comment // len(List) > 0
-}
-
-func (g *CommentGroup) Pos() Pos { return g.List[0].Pos() }
-func (g *CommentGroup) End() Pos { return g.List[len(g.List)-1].End() }
-
-func isWhitespace(ch byte) bool { return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' }
-
-func stripTrailingWhitespace(s string) string {
-	i := len(s)
-	for i > 0 && isWhitespace(s[i-1]) {
-		i--
-	}
-	return s[0:i]
-}
-
-// Text returns the text of the comment.
-// Comment markers (//, /*, and */), the first space of a line comment, and
-// leading and trailing empty lines are removed. Multiple empty lines are
-// reduced to one, and trailing space on lines is trimmed. Unless the result
-// is empty, it is newline-terminated.
-//
-func (g *CommentGroup) Text() string {
-	if g == nil {
-		return ""
-	}
-	comments := make([]string, len(g.List))
-	for i, c := range g.List {
-		comments[i] = c.Text
-	}
-
-	lines := make([]string, 0, 10) // most comments are less than 10 lines
-	for _, c := range comments {
-		// Remove comment markers.
-		// The parser has given us exactly the comment text.
-		switch c[1] {
-		case '/':
-			//-style comment (no newline at the end)
-			c = c[2:]
-			// strip first space - required for Example tests
-			if len(c) > 0 && c[0] == ' ' {
-				c = c[1:]
-			}
-		case '*':
-			/*-style comment */
-			c = c[2 : len(c)-2]
-		}
-
-		// Split on newlines.
-		cl := strings.Split(c, "\n")
-
-		// Walk lines, stripping trailing white space and adding to list.
-		for _, l := range cl {
-			lines = append(lines, stripTrailingWhitespace(l))
-		}
-	}
-
-	// Remove leading blank lines; convert runs of
-	// interior blank lines to a single blank line.
-	n := 0
-	for _, line := range lines {
-		if line != "" || n > 0 && lines[n-1] != "" {
-			lines[n] = line
-			n++
-		}
-	}
-	lines = lines[0:n]
-
-	// Add final "" entry to get trailing newline from Join.
-	if n > 0 && lines[n-1] != "" {
-		lines = append(lines, "")
-	}
-
-	return strings.Join(lines, "\n")
-}
-
-// ----------------------------------------------------------------------------
-// Miscellaneous and types
-
-type (
-	// A RestrictionSpec represents template restrictions
-	RestrictionSpec struct {
-		Kind    Token
-		KindPos Pos
-	}
-)
-
-// ----------------------------------------------------------------------------
-// Expressions and types
-
-// An expression is represented by a tree consisting of one
-// or more of the following concrete expression nodes.
+// Expressions
 //
 type (
-	// A BadExpr node is a placeholder for expressions containing
-	// syntax errors for which no correct expression nodes can be
-	// created.
-	//
-	BadExpr struct {
-		From, To Pos // position range of bad expression
-	}
-
-	// An Ident node represents an identifier.
 	Ident struct {
-		NamePos Pos    // identifier position
-		Name    string // identifier name
+		NamePos Pos
+		Name    string
+	}
+
+	ParametrizedIdent struct {
+		Ident  *Ident
+		Params Expr
 	}
 
 	ValueLiteral struct {
 		Kind     Token
 		ValuePos Pos
 		Value    string
+	}
+
+	CompositeLiteral struct {
 	}
 
 	UnaryExpr struct {
@@ -206,139 +82,45 @@ type (
 		Fun  Expr
 		Args []Expr
 	}
-)
 
-// Pos and End implementations for expression/type nodes.
-
-func (x *BadExpr) Pos() Pos      { return x.From }
-func (x *Ident) Pos() Pos        { return x.NamePos }
-func (x *ValueLiteral) Pos() Pos { return x.ValuePos }
-func (x *UnaryExpr) Pos() Pos    { return x.X.Pos() }
-func (x *BinaryExpr) Pos() Pos   { return x.X.Pos() }
-func (x *ParenExpr) Pos() Pos    { return x.List[0].Pos() }
-func (x *SelectorExpr) Pos() Pos { return x.X.Pos() }
-func (x *IndexExpr) Pos() Pos    { return x.X.Pos() }
-func (x *CallExpr) Pos() Pos     { return x.Fun.Pos() }
-
-func (x *BadExpr) End() Pos      { return x.To }
-func (x *Ident) End() Pos        { return Pos(int(x.NamePos) + len(x.Name)) }
-func (x *ValueLiteral) End() Pos { return x.ValuePos }
-func (x *UnaryExpr) End() Pos    { return x.X.End() }
-func (x *BinaryExpr) End() Pos   { return x.X.End() }
-func (x *ParenExpr) End() Pos    { return x.List[0].End() }
-func (x *SelectorExpr) End() Pos { return x.X.End() }
-func (x *IndexExpr) End() Pos    { return x.X.End() }
-func (x *CallExpr) End() Pos     { return x.Fun.End() }
-
-// exprNode() ensures that only expression/type nodes can be
-// assigned to an Expr.
-//
-func (*BadExpr) exprNode()        {}
-func (*Ident) exprNode()          {}
-func (x *ValueLiteral) exprNode() {}
-func (x *UnaryExpr) exprNode()    {}
-func (x *BinaryExpr) exprNode()   {}
-func (x *ParenExpr) exprNode()    {}
-func (x *SelectorExpr) exprNode() {}
-func (x *IndexExpr) exprNode()    {}
-func (x *CallExpr) exprNode()     {}
-
-// ----------------------------------------------------------------------------
-// Convenience functions for Idents
-
-// NewIdent creates a new Ident without position.
-// Useful for ASTs generated by code other than the Go
-//
-func NewIdent(name string) *Ident { return &Ident{NoPos, name} }
-
-func (id *Ident) String() string {
-	if id != nil {
-		return id.Name
-	}
-	return "<nil>"
-}
-
-// -----------------------------------------------------------------------
-// Types
-
-type Field struct {
-	Type     Expr
-	Name     Expr
-	Optional bool
-	In       bool
-	Out      bool
-}
-
-type FieldList struct {
-	From   Pos
-	Fields []*Field
-}
-
-func (x *Field) Pos() Pos     { return x.Type.Pos() }
-func (x *FieldList) Pos() Pos { return x.From }
-
-func (x *Field) End() Pos     { return x.Type.End() }
-func (x *FieldList) End() Pos { return x.Fields[len(x.Fields)-1].End() }
-
-func (x *Field) exprNode()     {}
-func (x *FieldList) exprNode() {}
-
-// ----------------------------------------------------------------------------
-// Declarations
-
-type (
-	ImportDecl struct {
-		ImportPos   Pos
-		Module      *Ident
-		ImportSpecs []ImportSpec
+	ModifiesExpr struct {
 	}
 
-	ImportSpec struct {
+	LengthExpr struct {
+		Pos Pos
+		X   Expr
+		Len Expr
 	}
 
-	ValueDecl struct {
-		DeclPos Pos
-		Kind    Token // VAR, CONST, MODULEPAT, TIMER, ...
-		Type    Expr
-		Decls   []Expr
+	RedirectExpr struct {
+		X            Expr
+		Pos          Pos
+		ValuePos     Pos
+		Value        Expr
+		ParamPos     Pos
+		Param        Expr
+		SenderPos    Pos
+		Sender       Expr
+		IndexPos     Pos
+		Index        Expr
+		TimestampPos Pos
+		Timestamp    Expr
 	}
 
-	FuncDecl struct {
-		FuncPos Pos
-		Kind    Token
-		Name    *Ident
-		Params  *FieldList
-		Return  Expr
-		RunsOn  Expr
-		Mtc     Expr
-		System  Expr
-		Extern  bool
-		Body    *BlockStmt
+	RegexpExpr struct {
 	}
 
-	SubType struct {
-		TypePos Pos
-		Name    *Ident
-		Type    Expr
+	PatternExpr struct {
+	}
+
+	DecmatchExpr struct {
+	}
+
+	DecodedExpr struct {
 	}
 )
 
-func (x *ImportDecl) Pos() Pos { return x.ImportPos }
-func (x *ValueDecl) Pos() Pos  { return x.DeclPos }
-func (x *FuncDecl) Pos() Pos   { return x.FuncPos }
-func (x *SubType) Pos() Pos    { return x.TypePos }
-
-func (x *ImportDecl) End() Pos { return x.Module.End() }
-func (x *ValueDecl) End() Pos  { return x.Decls[len(x.Decls)-1].End() }
-func (x *FuncDecl) End() Pos   { return x.Body.End() }
-func (x *SubType) End() Pos    { return x.Name.End() }
-
-func (x *ImportDecl) declNode() {}
-func (x *ValueDecl) declNode()  {}
-func (x *FuncDecl) declNode()   {}
-func (x *SubType) declNode()    {}
-
-// -----------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 // Statements
 
 type (
@@ -355,35 +137,166 @@ type (
 	ExprStmt struct {
 		Expr Expr
 	}
+
+	ForStmt struct {
+	}
+
+	WhileStmt struct {
+	}
+
+	DoWhileStmt struct {
+	}
+
+	IfStmt struct {
+	}
+
+	SelectStmt struct {
+	}
+
+	CaseSpec struct {
+	}
+
+	AltStmt struct {
+	}
 )
 
-func (x *BlockStmt) Pos() Pos { return x.LBrace }
-func (x *DeclStmt) Pos() Pos  { return x.Decl.Pos() }
-func (x *ExprStmt) Pos() Pos  { return x.Expr.Pos() }
+// ----------------------------------------------------------------------------
+// Declarations
 
-func (x *BlockStmt) End() Pos { return x.RBrace }
-func (x *DeclStmt) End() Pos  { return x.Decl.End() }
-func (x *ExprStmt) End() Pos  { return x.Expr.End() }
+type (
+	ValueDecl struct {
+		DeclPos Pos
+		Kind    Token // VAR, CONST, MODULEPAT, TIMER, ...
+		Type    Expr
+		Decls   []Expr
+	}
 
-func (x *BlockStmt) stmtNode() {}
-func (x *DeclStmt) stmtNode()  {}
-func (x *ExprStmt) stmtNode()  {}
+	FuncDecl struct {
+		FuncPos Pos
+		Kind    Token
+		Name    *Ident
+		Params  Expr
+		Return  Expr
+		RunsOn  Expr
+		Mtc     Expr
+		System  Expr
+		Extern  bool
+		Body    *BlockStmt
+	}
+
+	SignatureDecl struct {
+	}
+)
 
 // ----------------------------------------------------------------------------
-// Modules
+// Types
 
-type Module struct {
-	Doc      *CommentGroup   // associated documentation; or nil
-	Module   Pos             // position of "module" keyword
-	Name     *Ident          // module name
-	Decls    []Decl          // top-level declarations; or nil
-	Comments []*CommentGroup // list of all comments in the source file
-}
-
-func (f *Module) Pos() Pos { return f.Module }
-func (f *Module) End() Pos {
-	if n := len(f.Decls); n > 0 {
-		return f.Decls[n-1].End()
+type (
+	TypeDecl struct {
 	}
-	return f.Name.End()
-}
+
+	SubType struct {
+	}
+
+	ListType struct {
+	}
+
+	StructType struct {
+	}
+
+	Field struct {
+	}
+
+	EnumType struct {
+	}
+
+	BehaviourType struct {
+	}
+
+	ComponentType struct {
+	}
+
+	PortAttribute struct {
+	}
+
+	PortType struct {
+	}
+)
+
+// ----------------------------------------------------------------------------
+// Modules and Module Definitions
+
+type (
+	Module struct {
+		Module Pos
+		Name   *Ident
+		Decls  []Decl
+	}
+
+	ModuleDef struct {
+	}
+
+	GroupDecl struct {
+	}
+
+	FriendDecl struct {
+	}
+
+	ImportDecl struct {
+		ImportPos   Pos
+		Module      *Ident
+		ImportSpecs []ImportSpec
+	}
+
+	ImportSpec struct {
+	}
+
+	ImportStmt struct {
+	}
+
+	ExceptSpec struct {
+	}
+
+	ExceptStmt struct {
+	}
+)
+
+// ----------------------------------------------------------------------------
+// Miscellaneous
+
+type (
+	LanguageSpec struct {
+	}
+
+	RestrictionSpec struct {
+		Kind    Token
+		KindPos Pos
+	}
+
+	RunsOnSpec struct {
+	}
+
+	SystemSpec struct {
+	}
+
+	MtcSpec struct {
+	}
+
+	ReturnSpec struct {
+	}
+
+	FormalPars struct {
+		List []*FormalPar
+	}
+
+	FormalPar struct {
+		Type Expr
+		Name Expr
+	}
+
+	WithSpec struct {
+	}
+
+	WithStmt struct {
+	}
+)

--- a/ttcn3/syntax/ast.go
+++ b/ttcn3/syntax/ast.go
@@ -215,7 +215,7 @@ func (x *Ident) Pos() Pos        { return x.NamePos }
 func (x *ValueLiteral) Pos() Pos { return x.ValuePos }
 func (x *UnaryExpr) Pos() Pos    { return x.X.Pos() }
 func (x *BinaryExpr) Pos() Pos   { return x.X.Pos() }
-func (x *ParenExpr) Pos() Pos      { return x.List[0].Pos() }
+func (x *ParenExpr) Pos() Pos    { return x.List[0].Pos() }
 func (x *SelectorExpr) Pos() Pos { return x.X.Pos() }
 func (x *IndexExpr) Pos() Pos    { return x.X.Pos() }
 func (x *CallExpr) Pos() Pos     { return x.Fun.Pos() }
@@ -225,7 +225,7 @@ func (x *Ident) End() Pos        { return Pos(int(x.NamePos) + len(x.Name)) }
 func (x *ValueLiteral) End() Pos { return x.ValuePos }
 func (x *UnaryExpr) End() Pos    { return x.X.End() }
 func (x *BinaryExpr) End() Pos   { return x.X.End() }
-func (x *ParenExpr) End() Pos      { return x.List[0].End() }
+func (x *ParenExpr) End() Pos    { return x.List[0].End() }
 func (x *SelectorExpr) End() Pos { return x.X.End() }
 func (x *IndexExpr) End() Pos    { return x.X.End() }
 func (x *CallExpr) End() Pos     { return x.Fun.End() }
@@ -238,7 +238,7 @@ func (*Ident) exprNode()          {}
 func (x *ValueLiteral) exprNode() {}
 func (x *UnaryExpr) exprNode()    {}
 func (x *BinaryExpr) exprNode()   {}
-func (x *ParenExpr) exprNode()      {}
+func (x *ParenExpr) exprNode()    {}
 func (x *SelectorExpr) exprNode() {}
 func (x *IndexExpr) exprNode()    {}
 func (x *CallExpr) exprNode()     {}

--- a/ttcn3/syntax/ast.go
+++ b/ttcn3/syntax/ast.go
@@ -188,7 +188,7 @@ type (
 		Y     Expr
 	}
 
-	SetExpr struct {
+	ParenExpr struct {
 		List []Expr
 	}
 
@@ -215,7 +215,7 @@ func (x *Ident) Pos() Pos        { return x.NamePos }
 func (x *ValueLiteral) Pos() Pos { return x.ValuePos }
 func (x *UnaryExpr) Pos() Pos    { return x.X.Pos() }
 func (x *BinaryExpr) Pos() Pos   { return x.X.Pos() }
-func (x *SetExpr) Pos() Pos      { return x.List[0].Pos() }
+func (x *ParenExpr) Pos() Pos      { return x.List[0].Pos() }
 func (x *SelectorExpr) Pos() Pos { return x.X.Pos() }
 func (x *IndexExpr) Pos() Pos    { return x.X.Pos() }
 func (x *CallExpr) Pos() Pos     { return x.Fun.Pos() }
@@ -225,7 +225,7 @@ func (x *Ident) End() Pos        { return Pos(int(x.NamePos) + len(x.Name)) }
 func (x *ValueLiteral) End() Pos { return x.ValuePos }
 func (x *UnaryExpr) End() Pos    { return x.X.End() }
 func (x *BinaryExpr) End() Pos   { return x.X.End() }
-func (x *SetExpr) End() Pos      { return x.List[0].End() }
+func (x *ParenExpr) End() Pos      { return x.List[0].End() }
 func (x *SelectorExpr) End() Pos { return x.X.End() }
 func (x *IndexExpr) End() Pos    { return x.X.End() }
 func (x *CallExpr) End() Pos     { return x.Fun.End() }
@@ -238,7 +238,7 @@ func (*Ident) exprNode()          {}
 func (x *ValueLiteral) exprNode() {}
 func (x *UnaryExpr) exprNode()    {}
 func (x *BinaryExpr) exprNode()   {}
-func (x *SetExpr) exprNode()      {}
+func (x *ParenExpr) exprNode()      {}
 func (x *SelectorExpr) exprNode() {}
 func (x *IndexExpr) exprNode()    {}
 func (x *CallExpr) exprNode()     {}

--- a/ttcn3/syntax/parser.go
+++ b/ttcn3/syntax/parser.go
@@ -627,7 +627,7 @@ func (p *parser) parseOperand() Expr {
 		p.parseCallDecMatch()
 
 	case MODIF:
-		p.parseCallDecoded()
+		p.parseDecodedModifier()
 
 	default:
 		p.errorExpected(p.pos(1), "operand")
@@ -730,12 +730,12 @@ func (p *parser) parseCallDecMatch() {
 	p.parseExpr()
 }
 
-func (p *parser) parseCallDecoded() {
+func (p *parser) parseDecodedModifier() {
 	p.expect(MODIF) // @decoded
 	if p.tok(1) == LPAREN {
 		p.parseParenExpr()
 	}
-	p.parseExpr()
+	p.parsePrimaryExpr()
 }
 
 func (p *parser) parseSelectorExpr(x Expr) Expr {

--- a/ttcn3/syntax/parser.go
+++ b/ttcn3/syntax/parser.go
@@ -776,22 +776,6 @@ func (p *parser) parseCallExpr(x Expr) Expr {
 	}
 }
 
-func (p *parser) parseRunsOn() {
-	p.expect(RUNS)
-	p.expect(ON)
-	p.parseTypeRef()
-}
-
-func (p *parser) parseSystem() {
-	p.expect(SYSTEM)
-	p.parseTypeRef()
-}
-
-func (p *parser) parseMtc() {
-	p.expect(MTC)
-	p.parseTypeRef()
-}
-
 func (p *parser) parseLength() {
 	p.expect(LENGTH)
 	p.parseParenExpr()
@@ -1824,6 +1808,22 @@ func (p *parser) parseSignatureDecl() Decl {
 	}
 	p.parseWith()
 	return nil
+}
+
+func (p *parser) parseRunsOn() {
+	p.expect(RUNS)
+	p.expect(ON)
+	p.parseTypeRef()
+}
+
+func (p *parser) parseSystem() {
+	p.expect(SYSTEM)
+	p.parseTypeRef()
+}
+
+func (p *parser) parseMtc() {
+	p.expect(MTC)
+	p.parseTypeRef()
 }
 
 func (p *parser) parseReturn() Expr {

--- a/ttcn3/syntax/parser.go
+++ b/ttcn3/syntax/parser.go
@@ -679,7 +679,7 @@ func (p *parser) parseRef() Expr {
 	}
 
 	p.mark()
-	if x := p.tryTypeParameters(); x != nil && !isOperand(p.tok(1)) {
+	if x := p.tryTypeFormalPars(); x != nil && !isOperand(p.tok(1)) {
 		p.commit()
 		return id
 	}
@@ -849,14 +849,14 @@ func (p *parser) parseTypeRef() Expr {
 	return x
 }
 
-func (p *parser) tryTypeParameters() Expr {
+func (p *parser) tryTypeFormalPars() Expr {
 	if p.trace {
-		defer un(trace(p, "tryTypeParameters"))
+		defer un(trace(p, "tryTypeFormalPars"))
 	}
 	x := &Ident{Name: "dummy"}
 	p.next() // consume '<'
 	for p.tok(1) != GT {
-		y := p.tryTypeParameter()
+		y := p.tryTypeFormalPar()
 		if y == nil {
 			return nil
 		}
@@ -873,9 +873,9 @@ func (p *parser) tryTypeParameters() Expr {
 	return x
 }
 
-func (p *parser) tryTypeParameter() Expr {
+func (p *parser) tryTypeFormalPar() Expr {
 	if p.trace {
-		defer un(trace(p, "tryTypeParameter"))
+		defer un(trace(p, "tryTypeFormalPar"))
 	}
 	x := p.tryTypeIdent()
 L:
@@ -918,7 +918,7 @@ func (p *parser) tryTypeIdent() Expr {
 		return nil
 	}
 	if p.tok(1) == LT {
-		if x := p.tryTypeParameters(); x == nil {
+		if x := p.tryTypeFormalPars(); x == nil {
 			return nil
 		}
 	}
@@ -1323,7 +1323,7 @@ func (p *parser) parseStructType() {
 	}
 	p.parseIdent()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 	p.parseStructBody()
 	p.parseWith()
@@ -1377,7 +1377,7 @@ func (p *parser) parseListType() {
 	p.parseListBody()
 	p.parsePrimaryExpr()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 
 	if p.tok(1) == LPAREN {
@@ -1415,7 +1415,7 @@ func (p *parser) parseEnumType() {
 	p.next()
 	p.parseIdent()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 	p.parseEnumBody()
 	p.parseWith()
@@ -1447,7 +1447,7 @@ func (p *parser) parsePortType() {
 	p.next()
 	p.parseIdent()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 
 	switch p.tok(1) {
@@ -1484,7 +1484,7 @@ func (p *parser) parsePortAttribute() {
 	case MAP, UNMAP:
 		p.next()
 		p.expect(PARAM)
-		p.parseParameters()
+		p.parseFormalPars()
 	}
 }
 
@@ -1499,7 +1499,7 @@ func (p *parser) parseComponentType() {
 	p.next()
 	p.parseIdent()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 	if p.tok(1) == EXTENDS {
 		p.next()
@@ -1517,7 +1517,7 @@ func (p *parser) parseBehaviourTypeBody() {
 	if p.trace {
 		defer un(trace(p, "BehaviourTypeBody"))
 	}
-	p.parseParameters()
+	p.parseFormalPars()
 
 	if p.tok(1) == RUNS {
 		p.parseRunsOn()
@@ -1539,7 +1539,7 @@ func (p *parser) parseBehaviourType() {
 	p.next()
 	p.next()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 	p.parseBehaviourTypeBody()
 	p.parseWith()
@@ -1558,7 +1558,7 @@ func (p *parser) parseSubType() *SubType {
 	p.parseType()
 	p.parsePrimaryExpr()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 	// TODO(mef) fix constraints consumed by previous PrimaryExpr
 
@@ -1598,10 +1598,10 @@ func (p *parser) parseTemplateDecl() *ValueDecl {
 	x.Type = p.parseTypeRef()
 	p.parseIdent()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 	if p.tok(1) == LPAREN {
-		p.parseParameters()
+		p.parseFormalPars()
 	}
 	if p.tok(1) == MODIFIES {
 		p.next()
@@ -1615,7 +1615,7 @@ func (p *parser) parseTemplateDecl() *ValueDecl {
 }
 
 /*************************************************************************
- * Module Parameter
+ * Module FormalPar
  *************************************************************************/
 
 func (p *parser) parseModulePar() *ValueDecl {
@@ -1706,14 +1706,14 @@ func (p *parser) parseFuncDecl() *FuncDecl {
 	p.next()
 	x.Name = p.parseIdent()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 
 	if p.tok(1) == MODIF {
 		p.next()
 	}
 
-	x.Params = p.parseParameters()
+	x.Params = p.parseFormalPars()
 
 	if p.tok(1) == RUNS {
 		p.parseRunsOn()
@@ -1756,7 +1756,7 @@ func (p *parser) parseExtFuncDecl() *FuncDecl {
 		p.next()
 	}
 
-	x.Params = p.parseParameters()
+	x.Params = p.parseFormalPars()
 
 	if p.tok(1) == RUNS {
 		p.parseRunsOn()
@@ -1789,10 +1789,10 @@ func (p *parser) parseSignatureDecl() Decl {
 	p.next()
 	p.parseIdent()
 	if p.tok(1) == LT {
-		p.parseTypeParameters()
+		p.parseTypeFormalPars()
 	}
 
-	p.parseParameters()
+	p.parseFormalPars()
 
 	if p.tok(1) == NOBLOCK {
 		p.next()
@@ -1835,14 +1835,14 @@ func (p *parser) parseReturn() Expr {
 	return p.parseTypeRef()
 }
 
-func (p *parser) parseParameters() *FieldList {
+func (p *parser) parseFormalPars() *FieldList {
 	if p.trace {
-		defer un(trace(p, "Parameters"))
+		defer un(trace(p, "FormalPars"))
 	}
 	x := &FieldList{From: p.pos(1)}
 	p.expect(LPAREN)
 	for p.tok(1) != RPAREN {
-		x.Fields = append(x.Fields, p.parseParameter())
+		x.Fields = append(x.Fields, p.parseFormalPar())
 		if p.tok(1) != COMMA {
 			break
 		}
@@ -1852,9 +1852,9 @@ func (p *parser) parseParameters() *FieldList {
 	return x
 }
 
-func (p *parser) parseParameter() *Field {
+func (p *parser) parseFormalPar() *Field {
 	if p.trace {
-		defer un(trace(p, "Parameter"))
+		defer un(trace(p, "FormalPar"))
 	}
 	x := &Field{}
 
@@ -1877,13 +1877,13 @@ func (p *parser) parseParameter() *Field {
 	return x
 }
 
-func (p *parser) parseTypeParameters() {
+func (p *parser) parseTypeFormalPars() {
 	if p.trace {
-		defer un(trace(p, "TypeParameters"))
+		defer un(trace(p, "TypeFormalPars"))
 	}
 	p.expect(LT)
 	for p.tok(1) != GT {
-		p.parseTypeParameter()
+		p.parseTypeFormalPar()
 		if p.tok(1) != COMMA {
 			break
 		}
@@ -1892,9 +1892,9 @@ func (p *parser) parseTypeParameters() {
 	p.expect(GT)
 }
 
-func (p *parser) parseTypeParameter() {
+func (p *parser) parseTypeFormalPar() {
 	if p.trace {
-		defer un(trace(p, "TypeParameter"))
+		defer un(trace(p, "TypeFormalPar"))
 	}
 	if p.tok(1) == IN {
 		p.next()

--- a/ttcn3/syntax/parser.go
+++ b/ttcn3/syntax/parser.go
@@ -519,7 +519,7 @@ L:
 
 	if p.tok(1) == PARAM {
 		p.next()
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 
 	if p.tok(1) == ALIVE {
@@ -609,7 +609,7 @@ func (p *parser) parseOperand() Expr {
 
 	case LPAREN:
 		// can be template `x := (1,2,3)`, but also artihmetic expression: `1*(2+3)`
-		p.parseSetExpr()
+		p.parseParenExpr()
 
 	case LBRACK:
 		p.parseIndexExpr(nil)
@@ -687,7 +687,7 @@ func (p *parser) parseRef() Expr {
 	return id
 }
 
-func (p *parser) parseSetExpr() {
+func (p *parser) parseParenExpr() {
 	p.expect(LPAREN)
 	p.parseExprList()
 	p.expect(RPAREN)
@@ -711,7 +711,7 @@ func (p *parser) parseCallRegexp() {
 	if p.tok(1) == MODIF {
 		p.next()
 	}
-	p.parseSetExpr()
+	p.parseParenExpr()
 }
 
 func (p *parser) parseCallPattern() {
@@ -725,7 +725,7 @@ func (p *parser) parseCallPattern() {
 func (p *parser) parseCallDecMatch() {
 	p.expect(DECMATCH)
 	if p.tok(1) == LPAREN {
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 	p.parseExpr()
 }
@@ -733,7 +733,7 @@ func (p *parser) parseCallDecMatch() {
 func (p *parser) parseCallDecoded() {
 	p.expect(MODIF) // @decoded
 	if p.tok(1) == LPAREN {
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 	p.parseExpr()
 }
@@ -794,7 +794,7 @@ func (p *parser) parseMtc() {
 
 func (p *parser) parseLength() {
 	p.expect(LENGTH)
-	p.parseSetExpr()
+	p.parseParenExpr()
 }
 
 func (p *parser) parseRedirect() Expr {
@@ -1371,7 +1371,7 @@ func (p *parser) parseStructField() {
 	p.parsePrimaryExpr()
 
 	if p.tok(1) == LPAREN {
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 	if p.tok(1) == LENGTH {
 		p.parseLength()
@@ -1397,7 +1397,7 @@ func (p *parser) parseListType() {
 	}
 
 	if p.tok(1) == LPAREN {
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 
 	if p.tok(1) == LENGTH {
@@ -1579,7 +1579,7 @@ func (p *parser) parseSubType() *SubType {
 	// TODO(mef) fix constraints consumed by previous PrimaryExpr
 
 	if p.tok(1) == LPAREN {
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 	if p.tok(1) == LENGTH {
 		p.parseLength()
@@ -1820,7 +1820,7 @@ func (p *parser) parseSignatureDecl() Decl {
 
 	if p.tok(1) == EXCEPTION {
 		p.next()
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 	p.parseWith()
 	return nil
@@ -2006,7 +2006,7 @@ func (p *parser) parseForLoop() {
 
 func (p *parser) parseWhileLoop() {
 	p.next()
-	p.parseSetExpr()
+	p.parseParenExpr()
 	p.parseBlockStmt()
 }
 
@@ -2014,12 +2014,12 @@ func (p *parser) parseDoWhileLoop() {
 	p.next()
 	p.parseBlockStmt()
 	p.expect(WHILE)
-	p.parseSetExpr()
+	p.parseParenExpr()
 }
 
 func (p *parser) parseIfStmt() {
 	p.next()
-	p.parseSetExpr()
+	p.parseParenExpr()
 	p.parseBlockStmt()
 	if p.tok(1) == ELSE {
 		p.next()
@@ -2036,7 +2036,7 @@ func (p *parser) parseSelect() {
 	if p.tok(1) == UNION {
 		p.next()
 	}
-	p.parseSetExpr()
+	p.parseParenExpr()
 	p.expect(LBRACE)
 	for p.tok(1) == CASE {
 		p.parseCaseStmt()
@@ -2049,7 +2049,7 @@ func (p *parser) parseCaseStmt() {
 	if p.tok(1) == ELSE {
 		p.next()
 	} else {
-		p.parseSetExpr()
+		p.parseParenExpr()
 	}
 	p.parseBlockStmt()
 }

--- a/ttcn3/syntax/parser.go
+++ b/ttcn3/syntax/parser.go
@@ -989,7 +989,7 @@ func (p *parser) parseModuleDef() Decl {
 		p.next()
 		p.parseFriend()
 	case TYPE:
-		p.parseType()
+		p.parseTypeDecl()
 	case TEMPLATE:
 		p.parseTemplateDecl()
 	case MODULEPAR:
@@ -1252,7 +1252,7 @@ func (p *parser) parseWithQualifier() {
  * Type Definitions
  *************************************************************************/
 
-func (p *parser) parseType() Decl {
+func (p *parser) parseTypeDecl() Decl {
 	if p.trace {
 		defer un(trace(p, "Type"))
 	}
@@ -1284,7 +1284,7 @@ func (p *parser) parseType() Decl {
 	return nil
 }
 
-func (p *parser) parseNestedType() {
+func (p *parser) parseType() {
 	if p.trace {
 		defer un(trace(p, "NestedType"))
 	}
@@ -1351,7 +1351,7 @@ func (p *parser) parseStructField() {
 	if p.tok(1) == MODIF {
 		p.next() // @default
 	}
-	p.parseNestedType()
+	p.parseType()
 	p.parsePrimaryExpr()
 
 	if p.tok(1) == LPAREN {
@@ -1401,7 +1401,7 @@ func (p *parser) parseListBody() {
 	}
 
 	p.expect(OF)
-	p.parseNestedType()
+	p.parseType()
 }
 
 /*************************************************************************
@@ -1555,7 +1555,7 @@ func (p *parser) parseSubType() *SubType {
 		defer un(trace(p, "SubType"))
 	}
 
-	p.parseNestedType()
+	p.parseType()
 	p.parsePrimaryExpr()
 	if p.tok(1) == LT {
 		p.parseTypeParameters()

--- a/ttcn3/syntax/parser_test.go
+++ b/ttcn3/syntax/parser_test.go
@@ -249,7 +249,7 @@ func TestTypes(t *testing.T) {
 		{pass, `type altstep  as() runs on self return int`},
 		{pass, `type testcase tc() runs on C system TSI`},
 	}
-	testParse(t, types, func(p *parser) { p.parseType() })
+	testParse(t, types, func(p *parser) { p.parseTypeDecl() })
 }
 
 func TestStmts(t *testing.T) {

--- a/ttcn3/syntax/parser_test.go
+++ b/ttcn3/syntax/parser_test.go
@@ -203,7 +203,7 @@ func TestFormalPars(t *testing.T) {
 		{pass, `(out timer y := -, in value @fuzzy timer x := 1)`},
 		{pass, `(out timer y := -, in value timer x := (1,2,3))`},
 	}
-	testParse(t, formalPars, func(p *parser) { p.parseParameters() })
+	testParse(t, formalPars, func(p *parser) { p.parseFormalPars() })
 }
 
 func TestTypes(t *testing.T) {


### PR DESCRIPTION
This PR only introduces an AST skeleton, because a proper (Roslyn inspired) AST implementation, requires scanner and token handling to be refactored first.