### PR TITLE
Message coverage

### DIFF
--- a/cmd/k3-mcov/main.go
+++ b/cmd/k3-mcov/main.go
@@ -82,7 +82,7 @@ func main() {
 			continue
 		}
 
-		fmt.Println(k, count[k])
+		fmt.Printf("%s\t%d\n", k, count[k])
 	}
 }
 

--- a/cmd/k3-mcov/main.go
+++ b/cmd/k3-mcov/main.go
@@ -69,7 +69,19 @@ func main() {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	for _, k := range keys {
+	for i, k := range keys {
+
+		// Do not report matches of whole structs:
+		//
+		//      MessageA 0          <-- Do not display those lines
+		//      MessageA.Field1 23
+		//      MessageA.Field2 5
+		//      MessageA.Field3 0
+		//
+		if i+1 < len(keys) && strings.HasPrefix(keys[i+1], k+".") {
+			continue
+		}
+
 		fmt.Println(k, count[k])
 	}
 }

--- a/cmd/k3-mcov/main.go
+++ b/cmd/k3-mcov/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/nokia/ntt/internal/loc"
+	"github.com/nokia/ntt/internal/ttcn3/ast"
+	"github.com/nokia/ntt/internal/ttcn3/parser"
+	"github.com/nokia/ntt/internal/ttcn3/token"
+)
+
+var (
+	count = make(map[string]int)
+	line  = 0
+)
+
+func main() {
+
+	// Scanner reads stdin line by line
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line++
+		// We are only interested in ptrx events ending with +consume. Until we
+		// require other events for coverage, do the filtering before splitting
+		// the whole string.
+		if !strings.HasSuffix(scanner.Text(), "+consume") {
+			continue
+		}
+		s := strings.Split(scanner.Text(), "|")
+		if s[1] != "ptrx" {
+			continue
+		}
+
+		// Extract type and value from template string
+		tmpl := strings.TrimPrefix(s[4], "value=")
+		if tmpl == "" {
+			continue
+		}
+		idx := strings.IndexByte(tmpl, ':')
+		if idx < 0 {
+			continue
+		}
+		typ := tmpl[:idx]
+		tmpl = tmpl[idx+1:]
+
+		// Parse template
+		ast, err := parser.ParseExpr(loc.NewFileSet(), "stdin", tmpl)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		// Calculate coverage
+		if err := cover(typ, ast); err != nil {
+			log.Println(err)
+			continue
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Println(err)
+	}
+
+	// Report coverage
+	keys := make([]string, 0, len(count))
+	for k := range count {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Println(k, count[k])
+	}
+}
+
+func cover(typ string, tmpl ast.Expr) error {
+
+	switch x := tmpl.(type) {
+
+	// Low hanging fruits: We assume the k3 runtime log format uses assignment
+	// lists (`{ a:=1, b:=2}`) for structured types and value lists (`{1,2}`)
+	// for list types, so we don't need a ttcn3 typesystem, yet. We don't get
+	// full coverage for unions and optional fields, though.
+	case *ast.CompositeLiteral:
+		// An empty list means full coverage.
+		if len(x.List) == 0 {
+			count[typ]++
+			return nil
+		}
+
+		for i := range x.List {
+			switch x := x.List[i].(type) {
+			case *ast.BinaryExpr:
+				if x.Op.Kind != token.ASSIGN {
+					return notImplemented(typ, x)
+				}
+				if id, ok := x.X.(*ast.Ident); ok {
+					return cover(fmt.Sprintf("%s.%s", typ, id.String()), x.Y)
+				}
+				return notImplemented(typ, x.X)
+
+			default:
+				return cover(fmt.Sprintf("%s[%d]", typ, i), x)
+			}
+		}
+		return nil
+
+	// Scalar types are easy to evaluate
+	case *ast.ValueLiteral:
+		switch x.Tok.Kind {
+		// `?` and `*` do not increase counter, because they do not
+		// contribute to message coverage.
+		case token.ANY, token.MUL:
+			count[typ] += 0
+			return nil
+		case token.SUB,
+			token.INT,
+			token.BSTRING,
+			token.ERROR,
+			token.FAIL,
+			token.FALSE,
+			token.FLOAT,
+			token.INCONC,
+			token.NAN,
+			token.NONE,
+			token.PASS,
+			token.STRING,
+			token.TRUE,
+			token.OMIT,
+			token.NULL:
+			count[typ]++
+			return nil
+		}
+
+	}
+	return notImplemented(typ, tmpl)
+}
+
+func notImplemented(typ string, n ast.Node) error {
+	return errors.New(fmt.Sprintf("%d: Type %T for field %s not implemented.", line, n, typ))
+}

--- a/cmd/k3-mcov/main.go
+++ b/cmd/k3-mcov/main.go
@@ -146,6 +146,11 @@ func cover(typ string, tmpl ast.Expr) error {
 	case *ast.Ident:
 		count[typ]++
 		return nil
+
+	// Handle permution/superset/...
+	case *ast.CallExpr:
+		count[typ]++
+		return nil
 	}
 	return notImplemented(typ, tmpl)
 }

--- a/cmd/k3-mcov/main.go
+++ b/cmd/k3-mcov/main.go
@@ -118,9 +118,9 @@ func cover(typ string, tmpl ast.Expr) error {
 	// Scalar types are easy to evaluate
 	case *ast.ValueLiteral:
 		switch x.Tok.Kind {
-		// `?` and `*` do not increase counter, because they do not
+		// `omit`, `?` and `*` do not increase counter, because they do not
 		// contribute to message coverage.
-		case token.ANY, token.MUL:
+		case token.ANY, token.MUL, token.OMIT:
 			count[typ] += 0
 			return nil
 		case token.SUB,
@@ -136,7 +136,6 @@ func cover(typ string, tmpl ast.Expr) error {
 			token.PASS,
 			token.STRING,
 			token.TRUE,
-			token.OMIT,
 			token.NULL:
 			count[typ]++
 			return nil

--- a/cmd/k3-mcov/main.go
+++ b/cmd/k3-mcov/main.go
@@ -137,6 +137,10 @@ func cover(typ string, tmpl ast.Expr) error {
 			return nil
 		}
 
+	// Handle enums
+	case *ast.Ident:
+		count[typ]++
+		return nil
 	}
 	return notImplemented(typ, tmpl)
 }

--- a/cmd/k3-mcov/main.go
+++ b/cmd/k3-mcov/main.go
@@ -100,12 +100,17 @@ func cover(typ string, tmpl ast.Expr) error {
 					return notImplemented(typ, x)
 				}
 				if id, ok := x.X.(*ast.Ident); ok {
-					return cover(fmt.Sprintf("%s.%s", typ, id.String()), x.Y)
+					if err := cover(fmt.Sprintf("%s.%s", typ, id.String()), x.Y); err != nil {
+						return err
+					}
+					continue
 				}
 				return notImplemented(typ, x.X)
 
 			default:
-				return cover(fmt.Sprintf("%s[%d]", typ, i), x)
+				if err := cover(fmt.Sprintf("%s[%d]", typ, i), x); err != nil {
+					return err
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Extensive usage of `*` and `?` in templates causes gaps in message content
validation. A tool for detecting those gaps would help to improve test quality.


### Proposal

One example is worth a thousand words:

```
type record MessageA {
    integer a,
    integer b,
    integer c
}

type record MessageB {
    integer a,
    integer b
}

type record MessageC {
    integer a,
    float f
}

...
p.receive(MessageA:{1,?,2});
p.receive(MessageA:{1,?,?});
p.receive(MessageC:{?,0.1});
...
```

In this example we have three records of which only two are covered (partially). A
report would look like this (new lines are added for better readability):

```
Module1.MessageA.a	2
Module1.MessageA.b	0
Module1.MessageA.c	1
# COV	Module1.MessageA	2/3

Module1.MessageB.a	0
Module1.MessageB.b	0
# COV	Module1.MessageB	0/2

Module2.MessageC.a	0
Module2.MessageC.f	1
# COV	Module2.MessageC	1/2

# TOTAL	3/7 42.86%
```

The coverage of a field is reported in two columns. The first column is the full
qualified field ID and the second how often this field was matched in a
`receive` operation.

The lines starting with `#` help to easily answer common questions like "Which
messages are not fully covered?" and "What's the total coverage?"

### Considerations

**Can we use static analysis?**
The majority of involved templates are parametrized with runtime values. A pure
static analysis is not sufficient. I suggest using the k3 runtime logs instead.

**Which operations should we consider for coverage?**
Definitively `receive` operations. What about `match` operations and `select`
statements?

**Should we generate a coverage report for _all_ toplevel types or just the
used ones?**
Message coverage is mostly interesting for toplevel PDUs. However we cannot
decide which type is a PDU and which is not. Simply including all types in the
coverage report is not practicable, as it looks like there's a magnitude more
types than receive operations. For now it's sufficient to include only used
types.

**How to account for list types/supersets/permutations?**
**How to account for union types?**

### Comments are very much welcome.

Closes #53 