### PR TITLE
Make sessions world wide writeable

### DIFF
--- a/internal/session/flock/flock.go
+++ b/internal/session/flock/flock.go
@@ -121,6 +121,12 @@ func (f *Flock) setFh() error {
 		return err
 	}
 
+	// Some users might have a restrictive umask setting. It is okay to make the
+	// lock file world wide writable.
+	if err := os.Chmod(f.path, 0666); err != nil {
+		return err
+	}
+
 	// set the filehandle on the struct
 	f.fh = fh
 	return nil

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -110,6 +110,12 @@ func (s *storage) SetSessions(sessions []session) error {
 	}
 	defer file.Close()
 
+	// Some users might have a restrictive umask setting. It is okay to make the
+	// sessions file world wide writable.
+	if err := os.Chmod(s.sessionsFile, 0666); err != nil {
+		return err
+	}
+
 	for _, s := range sessions {
 		if _, err := file.WriteString(s.String() + "\n"); err != nil {
 			return err


### PR DESCRIPTION
ntt respects umask when creating shared lock file. This causes `permission denied` error on shared machines. By making session files world wide writeable we have less such errors.