### PR TITLE
Ignore chmod errors

### DIFF
--- a/internal/session/flock/flock.go
+++ b/internal/session/flock/flock.go
@@ -123,9 +123,7 @@ func (f *Flock) setFh() error {
 
 	// Some users might have a restrictive umask setting. It is okay to make the
 	// lock file world wide writable.
-	if err := os.Chmod(f.path, 0666); err != nil {
-		return err
-	}
+	os.Chmod(f.path, 0666)
 
 	// set the filehandle on the struct
 	f.fh = fh

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -112,9 +112,7 @@ func (s *storage) SetSessions(sessions []session) error {
 
 	// Some users might have a restrictive umask setting. It is okay to make the
 	// sessions file world wide writable.
-	if err := os.Chmod(s.sessionsFile, 0666); err != nil {
-		return err
-	}
+	os.Chmod(s.sessionsFile, 0666)
 
 	for _, s := range sessions {
 		if _, err := file.WriteString(s.String() + "\n"); err != nil {


### PR DESCRIPTION
The sessions files in /tmp/k3 have to be writable by any user.
Individual umask settings however prevent file being world wide
writable.
A previous fix therefore explicitly calls `os.Chmod(0666)` on all
session files. This introduced a new issue:

    chmod: operation not permitted

This is because permission of a file may only be changed by its owner or
by a privileged process (see man 2 chmod for details).

This commit ignores chmod errors. Which should be safe because follow up
situation should be caught by later error checks.