### PR TITLE
Prepare for first releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,62 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: k3
+    binary: k3
+    dir: ./cmd/k3
+
+  - id: k3objdump
+    binary: k3objdump
+    dir: ./cmd/k3objdump
+
+  - id: k3-mcov
+    binary: k3-mcov
+    dir: ./cmd/k3-mcov
+
+nfpms:
+  - file_name_template: '{{ .ProjectName }}.{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    homepage:  https://github.com/nokia/ntt
+    description: A versatile TTCN-3 toolkit
+    maintainer: Matthias Simon <matthias.simon@nokia.com>
+    license: BSD-3 Clause
+    vendor: Nokia
+
+    formats:
+      - deb
+      - rpm
+
+    recommends:
+      - git
+      - gcc
+      - gcc-c++
+      - golang
+
+    bindir: /usr/bin
+    replacements:
+      386: i386
+      amd64: x86_64
+
+archives:
+- builds: ["amd64"]
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - Merge branch

--- a/cmd/k3/main.go
+++ b/cmd/k3/main.go
@@ -47,6 +47,10 @@ var (
 	}
 
 	Verbose = false
+
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 func init() {

--- a/cmd/k3/version.go
+++ b/cmd/k3/version.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "show version",
+		Run:   versionInfo,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func versionInfo(cmd *cobra.Command, args []string) {
+	fmt.Printf("k3 %v, commit %v, built at %v\n", version, commit, date)
+}

--- a/internal/t3xf/opcode/opcode.go
+++ b/internal/t3xf/opcode/opcode.go
@@ -479,8 +479,8 @@ func Unpack(x uint32) (Opcode, int) {
 	case instrClass:
 		return Opcode(i >> 4 & 0xfff), i >> 16
 	case refClass:
-		if i&(1<<31) != 0 {
-			return FROZEN_REF, i &^ (1 << 31)
+		if uint32(i)&(1<<31) != 0 {
+			return FROZEN_REF, int(uint32(i) &^ (1 << 31))
 		}
 		return REF, i
 	case lineClass:


### PR DESCRIPTION
People who want to use [Visual Studio Code Extension for TTCN-3](https://marketplace.visualstudio.com/items?itemName=Nokia.ttcn3) need easy access to k3 language server. Downloading pre-compiled binaries are an easy option with [Goreleaser](https://goreleaser.com/).