### PR TITLE
Quote value of environment variables

### DIFF
--- a/cmd/k3/show.go
+++ b/cmd/k3/show.go
@@ -125,7 +125,7 @@ func show(cmd *cobra.Command, args []string) error {
 			"session_id",
 		} {
 			if s := stringers[key](suite); s != "" {
-				fmt.Printf("K3_%s=%s\n", strings.ToUpper(key), strings.Replace(s, "\n", " ", -1))
+				fmt.Printf("K3_%s=\"%s\"\n", strings.ToUpper(key), strings.Replace(s, "\n", " ", -1))
 			}
 		}
 

--- a/internal/ntt/env.go
+++ b/internal/ntt/env.go
@@ -49,7 +49,7 @@ func (suite *Suite) Environ() ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		ret = append(ret, fmt.Sprintf("%s=%s", k, v))
+		ret = append(ret, fmt.Sprintf("%s=\"%s\"", k, v))
 	}
 	return ret, nil
 }


### PR DESCRIPTION
`k3 show` and `ntt.Environ` will output quoted values for environment
variables.

This helps using k3 in shell scripts. Example:

        . <(k3 show -- env)