### PR TITLE
Allow shebang

### DIFF
--- a/internal/ttcn3/parser/parser.go
+++ b/internal/ttcn3/parser/parser.go
@@ -125,7 +125,9 @@ func (p *parser) handlePreproc(s string) {
 			p.error(p.pos(1), "malformed 'define' directive")
 		}
 	default:
-		p.error(p.pos(1), "unknown preprocessor directive")
+		if !strings.HasPrefix(s, "#!") {
+			p.error(p.pos(1), "unknown preprocessor directive")
+		}
 	}
 }
 


### PR DESCRIPTION
Beeing able to run ttcn3 files as script, could come in handy:

```
$ cat MyPluginTests.ttcn3 
#!k3 run -j
module MyPluginTests {
    testcase Test1() ...
    testcase Test2() ...
}
$ chmod +x MyPluginTests.ttcn3
$ ./MyPluginTests.ttcn3
```

