### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,98 @@
+PROJECT := github.com/nokia/ntt
+
+# Common GNU installation folders
+DESTDIR ?=
+PREFIX     ?= /ust/local
+BINDIR     ?= ${PREFIX}/bin
+LIBEXECDIR ?= ${PREFIX}/libexec
+MANDIR     ?= ${PREFIX}/share/man
+ETCDIR     ?= /etc
+
+BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
+ZSHINSTALLDIR=${PREFIX}/share/zsh/site-functions
+
+# Commands
+GO   ?= go
+
+# Go specific stuff
+export GO111MODULE=off
+export GOPROXY=https://proxy.golang.org
+
+GO_BUILD=$(GO) build
+
+# If GOPATH not specified, use one in the local directory
+ifeq ($(GOPATH),)
+export GOPATH := $(CURDIR)/_output
+unexport GOBIN
+endif
+FIRST_GOPATH := $(firstword $(subst :, ,$(GOPATH)))
+GOPKGDIR := $(FIRST_GOPATH)/src/$(PROJECT)
+GOPKGBASEDIR ?= $(shell dirname "$(GOPKGDIR)")
+
+GOBIN := $(shell $(GO) env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN := $(FIRST_GOPATH)/bin
+endif
+
+
+# Go module support: set `-mod=vendor` to force use the vendored sources
+ifeq ($(shell $(GO) help mod >/dev/null 2>&1 && echo true), true)
+	GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
+endif
+
+
+#GCFLAGS ?= all=-trimpath=${PWD}
+#ASMFLAGS ?= all=-trimpath=${PWD}
+#LDFLAGS_NTT ?= \
+#	  -X $(CMD_NTT)/define.gitCommit=$(GIT_COMMIT) \
+#	  -X $(CMD_NTT)/define.buildInfo=$(BUILD_INFO) \
+#	  -X $(CMD_NTT)/config._installPrefix=$(PREFIX) \
+#	  -X $(CMD_NTT)/config._etcDir=$(ETCDIR) \
+#	  $(EXTRA_LDFLAGS)
+#
+#SOURCES = $(shell find . -path './.*' -prune -o -name "*.go")
+
+#COMMIT_NO ?= $(shell git rev-parse HEAD 2> /dev/null || true)
+#GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+#DATE_FMT = %s
+#ifdef SOURCE_DATE_EPOCH
+#	BUILD_INFO ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+#	ISODATE ?= $(shell date -d "@$(SOURCE_DATE_EPOCH)" --iso-8601)
+#else
+#	BUILD_INFO ?= $(shell date "+$(DATE_FMT)")
+#	ISODATE ?= $(shell date --iso-8601)
+#endif
+
+.PHONY: all ## build whole project (default)
+all: build
+
+# It's common practice to provide a help target describing available targets.
+# This script greps through the Makefile and displays all phony-targets with a
+# `##` help string.
+.PHONY: help
+help:
+	@echo Available targets:
+	@perl -ne 'printf("\t%-10s\t%s\n", $$1, $$2)  if /^\.PHONY:\s*(.*)\s*##\s*(.*)$$/' <$(MAKEFILE_LIST)
+
+.PHONY: build ## build everything
+build: ntt
+
+.PHONY: check ## run tests
+check:
+	$(GO) test ./...
+
+.PHONY: install ## install NTT
+install: build
+	install -d -m 755 $(DESTDIR)$(BINDIR)
+	install -m 755 bin/ntt $(DESTDIR)$(BINDIR)/ntt
+
+
+# Binaries must be PHONY-targets, because
+.PHONY: ntt ## build ntt CLI
+ntt:
+	$(GO_BUILD) -o $@ ./cmd/ntt
+
+.PHONY: generate ## run code generators
+generate:
+	$(GO) generate -x ./...
+

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PREFIX     ?= /usr/local
 BINDIR     ?= ${PREFIX}/bin
 LIBEXECDIR ?= ${PREFIX}/libexec
 MANDIR     ?= ${PREFIX}/share/man
+DATADIR    ?= ${PREFIX}/share/ntt
 ETCDIR     ?= /etc
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
@@ -67,7 +68,7 @@ help:
 	@perl -ne 'printf("\t%-10s\t%s\n", $$1, $$2)  if /^\.PHONY:\s*(.*)\s*##\s*(.*)$$/' <$(MAKEFILE_LIST)
 
 .PHONY: build ## build everything
-build: ntt
+build: bin/ntt bin/ntt-mcov bin/k3objdump
 
 .PHONY: check ## run tests
 check:
@@ -77,16 +78,29 @@ check:
 install: build
 	install -d -m 755 $(DESTDIR)$(BINDIR)
 	install -m 755 bin/ntt $(DESTDIR)$(BINDIR)/ntt
+	install -m 755 bin/ntt-mcov $(DESTDIR)$(BINDIR)/ntt-mcov
+	install -m 755 bin/k3objdump $(DESTDIR)$(BINDIR)/k3objdump
+	install -d -m 755 $(DESTDIR)$(DATADIR)/cmake
+	install -m 644 cmake/FindNTT.cmake $(DESTDIR)$(DATADIR)/cmake
 
 
 .PHONY: clean ## delete build artifacts
 clean:
-	rm -f ntt
+	rm -f bin/ntt bin/ntt-mcov bin/k3objdump
+	rmdir bin
 
-# Binaries must be PHONY-targets, because
-.PHONY: ntt ## build ntt CLI
-ntt:
+.PHONY: bin/ntt ## build ntt CLI
+bin/ntt:
 	$(GO_BUILD) -ldflags="$(NTT_LDFLAGS)" -o $@ ./cmd/ntt
+
+.PHONY: bin/ntt-mcov ## build ntt-mcov CLI
+
+bin/ntt-mcov:
+	$(GO_BUILD) -ldflags="$(NTT_LDFLAGS)" -o $@ ./cmd/ntt-mcov
+
+.PHONY: bin/k3objdump ## build k3objdump CLI
+bin/k3objdump:
+	$(GO_BUILD) -ldflags="$(NTT_LDFLAGS)" -o $@ ./cmd/k3objdump
 
 .PHONY: generate ## run code generators
 generate:

--- a/README.md
+++ b/README.md
@@ -88,43 +88,16 @@ manager of your choice. You can also install directly from the internet:
 
 ## Compiling from Source
 
-Because this is a Go project you may use the usual Go methods to build and
-install NTT. Note, you usually won't have proper version info.
+NTT requires a [Go compiler](https://golang.org/dl/) >= 1.10, git and make to
+build. To build and install simply call:
 
-NTT requires only a [Go compiler](https://golang.org/dl/) >= 1.10 to build. The
-simplest method to build and install NTT is by `go get`. 
+	make
+	sudo make install
 
+You may control installation by specifying PREFIX and DESTDIR variables. For example:
 
-**Go Get**
-
-`go get` will download, build and install NTT into your GOPATH:
-
-        go get -u github.com/nokia/ntt/cmd/...
-
-You'll find the commands usually in `$HOME/go/bin`.
-
-
-**Git Clone && Go Build**
-
-For the manual method you also need a Git client. You can decide where to
-clone the repository or where to install NTT:
-
-    $ git clone https://github.com/nokia/ntt.git
-    $ cd ntt
-    $ go build ./cmd/ntt
-
-Go will download all dependencies, if you have Go modules support available. If
-you don't want Go to connect to the Internet, you may disable Go proxies and
-enable vendoring:
-
-    $ GOPROXY=off go build -mod=vendor ./cmd/ntt
-
-
-If you want to provide your own version information, you may also pass linker flags:
-
-    $ go build -ldflags="-X main.version=1.2.3 -X main.commit=deadbeef123 -X main.date=today" ./cmd/ntt
-    $ ./ntt version
-    ntt 1.2.3, commit deadbeef123, built at today
+	make PREFIX=/
+	make install DESTDIR=$HOME/.local
 
 
 # Getting Started


### PR DESCRIPTION
A Makefile is still the universal interface for building and installing software. A Makefile has some major advantages over using go tool directly:
* Version information is set up correctly.
* A user does not need to be familiar with go tool.
* Non-go components are easy to add.
* Most packaging scripts already know how to handle make.
