### PR TITLE
Improve logging of language server

### DIFF
--- a/internal/lsp/server_gen.go
+++ b/internal/lsp/server_gen.go
@@ -56,8 +56,8 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 	return s.didOpen(ctx, params)
 }
 
-func (s *Server) DidSave(context.Context, *protocol.DidSaveTextDocumentParams) error {
-	return notImplemented("DidSave")
+func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocumentParams) error {
+	return s.didSave(ctx, params)
 }
 
 func (s *Server) DocumentColor(context.Context, *protocol.DocumentColorParams) ([]protocol.ColorInformation, error) {

--- a/internal/lsp/server_gen.go
+++ b/internal/lsp/server_gen.go
@@ -180,8 +180,8 @@ func (s *Server) SemanticTokensRange(context.Context, *protocol.SemanticTokensRa
 	return nil, notImplemented("SemanticTokensRange")
 }
 
-func (s *Server) SetTraceNotification(context.Context, *protocol.SetTraceParams) error {
-	return notImplemented("SetTraceNotification")
+func (s *Server) SetTraceNotification(ctx context.Context, params *protocol.SetTraceParams) error {
+	return s.setTraceNotification(ctx, params)
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {

--- a/internal/lsp/text_synchronization.go
+++ b/internal/lsp/text_synchronization.go
@@ -25,6 +25,10 @@ func (s *Server) didChange(ctx context.Context, params *protocol.DidChangeTextDo
 	return nil
 }
 
+func (s *Server) didSave(ctx context.Context, params *protocol.DidSaveTextDocumentParams) error {
+	return nil
+}
+
 func (s *Server) didClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
 	f := s.suite.File(params.TextDocument.URI)
 	f.Reset()

--- a/internal/lsp/trace.go
+++ b/internal/lsp/trace.go
@@ -1,0 +1,11 @@
+package lsp
+
+import (
+	"context"
+
+	"github.com/nokia/ntt/internal/lsp/protocol"
+)
+
+func (s *Server) setTraceNotification(ctx context.Context, params *protocol.SetTraceParams) error {
+	return nil
+}


### PR DESCRIPTION
The language server should not print errors directly to stderr, but to the language server client instead. Further it should be possible to configure log-levels.