### PR TITLE
Add global error handler

### DIFF
--- a/cmd/ntt/show.go
+++ b/cmd/ntt/show.go
@@ -43,10 +43,7 @@ var (
 		},
 
 		"timeout": func(suite *ntt.Suite) string {
-			t, err := suite.Timeout()
-			if err != nil {
-				fatal(err)
-			}
+			t := suite.Timeout()
 			if t > 0 {
 				return fmt.Sprint(t)
 			}
@@ -120,6 +117,8 @@ func show(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
+	suite.SetErrorHandler(func(e error) { err = e })
+
 	if len(keys) == 0 {
 		for _, key := range []string{
 			"name",
@@ -137,7 +136,7 @@ func show(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		return nil
+		return err
 	}
 
 	for _, key := range keys {
@@ -155,7 +154,7 @@ func show(cmd *cobra.Command, args []string) error {
 
 		fmt.Println(s)
 	}
-	return nil
+	return err
 }
 
 // splitArgs splits an argument list at pos. Pos is usually the position of '--'

--- a/cmd/ntt/show.go
+++ b/cmd/ntt/show.go
@@ -27,11 +27,7 @@ var (
 		},
 
 		"sources": func(suite *ntt.Suite) string {
-			srcs, err := suite.Sources()
-			if err != nil {
-				fatal(err)
-			}
-			return strings.Join(ntt.PathSlice(srcs...), "\n")
+			return strings.Join(ntt.PathSlice(suite.Sources()...), "\n")
 		},
 
 		"imports": func(suite *ntt.Suite) string {

--- a/cmd/ntt/show.go
+++ b/cmd/ntt/show.go
@@ -36,10 +36,10 @@ var (
 
 		"timeout": func(suite *ntt.Suite) string {
 			t := suite.Timeout()
-			if t > 0 {
-				return fmt.Sprint(t)
+			if t <= 0 {
+				return ""
 			}
-			return ""
+			return fmt.Sprint(t)
 
 		},
 

--- a/cmd/ntt/show.go
+++ b/cmd/ntt/show.go
@@ -19,11 +19,7 @@ var (
 
 	stringers = map[string]func(suite *ntt.Suite) string{
 		"name": func(suite *ntt.Suite) string {
-			s, err := suite.Name()
-			if err != nil {
-				fatal(err)
-			}
-			return s
+			return suite.Name()
 		},
 
 		"sources": func(suite *ntt.Suite) string {

--- a/cmd/ntt/show.go
+++ b/cmd/ntt/show.go
@@ -31,11 +31,7 @@ var (
 		},
 
 		"imports": func(suite *ntt.Suite) string {
-			imps, err := suite.Imports()
-			if err != nil {
-				fatal(err)
-			}
-			return strings.Join(ntt.PathSlice(imps...), "\n")
+			return strings.Join(ntt.PathSlice(suite.Imports()...), "\n")
 		},
 
 		"timeout": func(suite *ntt.Suite) string {

--- a/internal/cmds/dump/main.go
+++ b/internal/cmds/dump/main.go
@@ -23,10 +23,8 @@ func dump(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	srcs, err := suite.Files()
-	if err != nil {
-		return err
-	}
+	suite.SetErrorHandler(func(e error) { err = e })
+	srcs := suite.Files()
 
 	var (
 		asts = make([]*ntt.ParseInfo, len(srcs))
@@ -50,5 +48,5 @@ func dump(cmd *cobra.Command, args []string) error {
 		fmt.Println(string(b))
 	}
 
-	return nil
+	return err
 }

--- a/internal/cmds/lint/main.go
+++ b/internal/cmds/lint/main.go
@@ -35,16 +35,14 @@ func lint(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	files, err := suite.Files()
-	if err != nil {
-		return err
-	}
+	suite.SetErrorHandler(func(e error) { err = e })
+	files := suite.Files()
 
-	for i := range files {
+	for i := range suite.Files() {
 		info := suite.Parse(files[i])
 		if info.Err != nil {
 			return err
 		}
 	}
-	return nil
+	return err
 }

--- a/internal/cmds/list/main.go
+++ b/internal/cmds/list/main.go
@@ -219,18 +219,18 @@ func parseFiles(cmd *cobra.Command, suite *ntt.Suite) error {
 		err  error
 	)
 
+	suite.SetErrorHandler(func(e error) { err = e })
+
 	// When listing tests we do not need to parse the whole suite and may
 	// ignore imported modules.
 	switch cmd.Name() {
 	case "tests", "list":
-		// TODO(5nord) Move handler up a layer.
-		suite.SetErrorHandler(func(e error) { err = e })
 		srcs = ntt.PathSlice(suite.Sources()...)
-		suite.SetErrorHandler(nil)
 	default:
-		srcs, err = suite.Files()
+		srcs = suite.Files()
 	}
 
+	suite.SetErrorHandler(nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmds/list/main.go
+++ b/internal/cmds/list/main.go
@@ -219,11 +219,14 @@ func parseFiles(cmd *cobra.Command, suite *ntt.Suite) error {
 		err  error
 	)
 
+	// When listing tests we do not need to parse the whole suite and may
+	// ignore imported modules.
 	switch cmd.Name() {
 	case "tests", "list":
-		var x []*ntt.File
-		x, err = suite.Sources()
-		srcs = ntt.PathSlice(x...)
+		// TODO(5nord) Move handler up a layer.
+		suite.SetErrorHandler(func(e error) { err = e })
+		srcs = ntt.PathSlice(suite.Sources()...)
+		suite.SetErrorHandler(nil)
 	default:
 		srcs, err = suite.Files()
 	}

--- a/internal/cmds/tags/main.go
+++ b/internal/cmds/tags/main.go
@@ -35,10 +35,8 @@ func tags(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	files, err := suite.Files()
-	if err != nil {
-		return err
-	}
+	suite.SetErrorHandler(func(e error) { err = e })
+	files := suite.Files()
 
 	var wg sync.WaitGroup
 	wg.Add(len(files))

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -31,11 +31,7 @@ func (s *Server) Diagnose() {
 	defer s.syncDiagnostics()
 
 	// Just do a very basic test if all .ttcn3 files are accessable.
-	_, err := s.suite.Files()
-	if err != nil {
-		s.reportError(err)
-		return
-	}
+	s.suite.Files()
 
 }
 

--- a/internal/ntt/env.go
+++ b/internal/ntt/env.go
@@ -39,7 +39,7 @@ var knownVars = map[string]bool{
 func (suite *Suite) Environ() ([]string, error) {
 	allKeys := make(map[string]struct{})
 
-	if vars, _ := suite.Variables(); vars != nil {
+	if vars := suite.Variables(); vars != nil {
 		for k := range vars {
 			allKeys[k] = struct{}{}
 		}
@@ -146,11 +146,7 @@ func (suite *Suite) getenv(key string, visited map[string]string) (string, error
 	// We must not look for NTT_CACHE in variables sections of package.yml,
 	// because this would create an endless loop.
 	if key != "NTT_CACHE" && key != "K3_CACHE" {
-		v, err := suite.Variables()
-		if err != nil {
-			return "", err
-		}
-		if v != nil {
+		if v := suite.Variables(); v != nil {
 			if s, ok := v[key]; ok {
 				s, err := suite.expand(s, visited)
 				visited[key] = s

--- a/internal/ntt/errors.go
+++ b/internal/ntt/errors.go
@@ -1,17 +1,9 @@
 package ntt
 
 import (
-	"github.com/nokia/ntt/internal/loc"
 	errors "golang.org/x/xerrors"
 )
 
 var (
-	ErrSyntax           = errors.New("syntax error")
-	ErrNoSuchIdentifier = errors.New("no such identifier")
-	ErrRedefinition     = errors.New("redefinition")
-	ErrNoIdentFound     = errors.New("no identifier found")
+	ErrNoIdentFound = errors.New("no identifier found")
 )
-
-type SyntaxError struct {
-	Pos, End loc.Position
-}

--- a/internal/ntt/identifier.go
+++ b/internal/ntt/identifier.go
@@ -46,7 +46,7 @@ func (suite *Suite) IdentifierAt(file string, line int, column int) (*IdentInfo,
 		// Try our luck in imported modules.
 		mod := syms.Modules[syntax.Module.Name.String()]
 		for i := range mod.Imports {
-			if file, _ := suite.FindModule(mod.Imports[i]); file != "" {
+			if file := suite.FindModule(mod.Imports[i]); file != "" {
 				if syntax := suite.Parse(file); syntax.Module != nil {
 					syms := suite.symbols(syntax)
 					imp := syms.Modules[mod.Imports[i]]

--- a/internal/ntt/manifest.go
+++ b/internal/ntt/manifest.go
@@ -472,7 +472,7 @@ func (suite *Suite) Files() []string {
 }
 
 // FindModule tries to find a .ttcn3 based on its module name.
-func (suite *Suite) FindModule(name string) (string, error) {
+func (suite *Suite) FindModule(name string) string {
 
 	suite.modulesMu.Lock()
 	defer suite.modulesMu.Unlock()
@@ -482,15 +482,15 @@ func (suite *Suite) FindModule(name string) (string, error) {
 	}
 
 	if file, ok := suite.modules[name]; ok {
-		return file, nil
+		return file
 	}
 
 	for _, file := range suite.Files() {
 		if filepath.Base(file) == name+".ttcn3" {
 			suite.modules[name] = file
-			return file, nil
+			return file
 		}
 	}
 
-	return "", fmt.Errorf("No such module %q", name)
+	return ""
 }

--- a/internal/ntt/manifest.go
+++ b/internal/ntt/manifest.go
@@ -247,15 +247,15 @@ func (suite *Suite) SetName(name string) {
 
 // Variables will return a string map containing the variables-sections of the
 // manifest files.
-func (suite *Suite) Variables() (map[string]string, error) {
+func (suite *Suite) Variables() map[string]string {
 	m, err := suite.parseManifest()
 	if err != nil {
-		return nil, err
+		suite.reportError(err)
 	}
 	if m != nil && m.Variables != nil {
-		return m.Variables, nil
+		return m.Variables
 	}
-	return nil, nil
+	return nil
 }
 
 // TestHook return the File object to the test hook. If not hook was found, it

--- a/internal/ntt/manifest.go
+++ b/internal/ntt/manifest.go
@@ -11,31 +11,31 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Timeout returns the configured timeout of the Suite. If there's no timeout,
-// the function will return 0.
-//
-// The error will be != nil if timeout could not be determined correctly. For
-// example, when `package.yml` had syntax errors.
-func (suite *Suite) Timeout() (float64, error) {
+// Timeout returns the configured timeout of the Suite. If timeout could not
+// retrieved, the function will return 0.
+func (suite *Suite) Timeout() float64 {
 	s, err := suite.Getenv("NTT_TIMEOUT")
 	if err != nil {
-		return 0, err
+		suite.reportError(err)
+		return 0
 	}
 	if s != "" {
 		f, err := strconv.ParseFloat(s, 64)
 		if err != nil {
-			return 0, err
+			suite.reportError(err)
+			return 0
 		}
-		return f, nil
+		return f
 	}
 	m, err := suite.parseManifest()
 	if err != nil {
-		return 0, err
+		suite.reportError(err)
+		return 0
 	}
 	if m != nil {
-		return m.Timeout, nil
+		return m.Timeout
 	}
-	return 0, nil
+	return 0
 }
 
 // Sources returns the list of sources required to compile a Suite.

--- a/internal/ntt/manifest.go
+++ b/internal/ntt/manifest.go
@@ -455,20 +455,20 @@ func (suite *Suite) parseManifest() (*manifest, error) {
 	return &data.manifest, data.err
 }
 
-// Files returns all .ttcn3 available. It will not return generated .ttcn3 files.
-// On error Files will return an error.
-func (suite *Suite) Files() ([]string, error) {
+// Files returns all .ttcn3 file available.
+func (suite *Suite) Files() []string {
 	srcs := suite.Sources()
 	files := PathSlice(srcs...)
 
 	for _, dir := range suite.Imports() {
 		f, err := findTTCN3Files(dir.Path())
 		if err != nil {
-			return nil, err
+			suite.reportError(err)
+			continue
 		}
 		files = append(files, f...)
 	}
-	return files, nil
+	return files
 }
 
 // FindModule tries to find a .ttcn3 based on its module name.
@@ -485,12 +485,10 @@ func (suite *Suite) FindModule(name string) (string, error) {
 		return file, nil
 	}
 
-	if files, err := suite.Files(); err == nil {
-		for _, file := range files {
-			if filepath.Base(file) == name+".ttcn3" {
-				suite.modules[name] = file
-				return file, nil
-			}
+	for _, file := range suite.Files() {
+		if filepath.Base(file) == name+".ttcn3" {
+			suite.modules[name] = file
+			return file, nil
 		}
 	}
 

--- a/internal/ntt/manifest_test.go
+++ b/internal/ntt/manifest_test.go
@@ -161,20 +161,25 @@ func TestSources(t *testing.T) {
 }
 
 func TestImports(t *testing.T) {
+	var err error
+
 	suite := &ntt.Suite{}
 	suite.SetRoot("./testdata/suite2")
+	suite.SetErrorHandler(func(e error) { err = e })
 
 	// This handle is used to overwrite package.yml with custom import testing
 	// stuff.
 	conf := suite.File("./testdata/suite2/package.yml")
 
 	conf.SetBytes([]byte(`imports: [ "dir1" ]`))
-	v, err := suite.Imports()
+	err = nil
+	v := suite.Imports()
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"testdata/suite2/dir1"}, strs(v))
 
 	conf.SetBytes([]byte(`imports: [ "${SOMETHING_UNKNOWN}/dir1" ]`))
-	v, err = suite.Imports()
+	err = nil
+	v = suite.Imports()
 	assert.NotNil(t, err)
 	assert.Nil(t, v)
 }

--- a/internal/ntt/manifest_test.go
+++ b/internal/ntt/manifest_test.go
@@ -185,41 +185,50 @@ func TestImports(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
+	var err error
 	suite := &ntt.Suite{}
+	suite.SetErrorHandler(func(e error) { err = e })
 
 	// Initial call to name shall return an error.
-	n, err := suite.Name()
+	err = nil
+	n := suite.Name()
 	assert.NotNil(t, err)
 	assert.Equal(t, "", n)
 
 	suite.AddSources("${SOMETHING}/dir1.ttcn3/foo.ttcn3", "bar", "fnord.ttcn3")
-	n, err = suite.Name()
+	err = nil
+	n = suite.Name()
 	assert.Nil(t, err)
 	assert.Equal(t, "foo", n)
 
 	suite.SetRoot("testdata/suite2")
-	n, err = suite.Name()
+	err = nil
+	n = suite.Name()
 	assert.Nil(t, err)
 	assert.Equal(t, "suite2", n)
 
 	suite.AddSources("${SOMETHING}/dir1.ttcn3/foo.ttcn3", "bar", "fnord.ttcn3")
-	n, err = suite.Name()
+	err = nil
+	n = suite.Name()
 	assert.Nil(t, err)
 	assert.Equal(t, "suite2", n)
 
 	conf := suite.File("testdata/suite2/package.yml")
 	conf.SetBytes([]byte("name: fnord"))
-	n, err = suite.Name()
+	err = nil
+	n = suite.Name()
 	assert.Nil(t, err)
 	assert.Equal(t, "fnord", n)
 
 	conf.SetBytes([]byte(`name: [ 23.5, "See fnords, now!"]`))
-	n, err = suite.Name()
+	err = nil
+	n = suite.Name()
 	assert.NotNil(t, err)
-	assert.Equal(t, "", n)
+	assert.Equal(t, "suite2", n)
 
 	suite.SetName("haaraxwd")
-	n, err = suite.Name()
+	err = nil
+	n = suite.Name()
 	assert.Nil(t, err)
 	assert.Equal(t, "haaraxwd", n)
 }

--- a/internal/ntt/manifest_test.go
+++ b/internal/ntt/manifest_test.go
@@ -91,35 +91,44 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestSources(t *testing.T) {
+
 	t.Run("Empty", func(t *testing.T) {
 		suite := &ntt.Suite{}
-		v, err := suite.Sources()
-		assert.Nil(t, err)
+		v := suite.Sources()
 		assert.Equal(t, 0, len(v))
 	})
 
 	t.Run("Files", func(t *testing.T) {
+		var (
+			v   []*ntt.File
+			err error
+		)
+
 		suite := &ntt.Suite{}
+		suite.SetErrorHandler(func(e error) { err = e })
 
 		// Now we are adding two source manually without having a root folder.
 		// Multiple calls to Sources should not change the number of Sources.
 		suite.AddSources("a.ttcn3", "b.ttcn3")
-		v, err := suite.Sources()
+		err = nil
+		v = suite.Sources()
 		for i := 0; i < 10; i++ {
-			v, err = suite.Sources()
+			v = suite.Sources()
 		}
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"a.ttcn3", "b.ttcn3"}, strs(v))
 
 		// Identical files may be added twice.
 		suite.AddSources("a.ttcn3", "b.ttcn3")
-		v, err = suite.Sources()
+		err = nil
+		v = suite.Sources()
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"a.ttcn3", "b.ttcn3", "a.ttcn3", "b.ttcn3"}, strs(v))
 
 		// Environment shall overwrite configured sources.
 		os.Setenv("NTT_SOURCES", "x.ttcn3	y.ttcn3")
-		v, err = suite.Sources()
+		err = nil
+		v = suite.Sources()
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"x.ttcn3", "y.ttcn3"}, strs(v))
 		os.Unsetenv("NTT_SOURCES")
@@ -129,14 +138,16 @@ func TestSources(t *testing.T) {
 		// This root contains just some .ttcn3 files without manifest.
 		suite.SetRoot("./testdata/suite1")
 		suite.AddSources("a.ttcn3", "b.ttcn3")
-		v, err = suite.Sources()
+		err = nil
+		v = suite.Sources()
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"testdata/suite1/a.ttcn3", "testdata/suite1/x.ttcn3", "a.ttcn3", "b.ttcn3"}, strs(v))
 
 		// This root contains a manifest.
 		suite.SetRoot("./testdata/suite2")
 		suite.AddSources("a.ttcn3", "b.ttcn3")
-		v, err = suite.Sources()
+		err = nil
+		v = suite.Sources()
 		assert.Nil(t, err)
 		assert.Equal(t, []string{
 			"testdata/suite2/a1.ttcn3",

--- a/internal/ntt/manifest_test.go
+++ b/internal/ntt/manifest_test.go
@@ -12,56 +12,79 @@ func TestTimeout(t *testing.T) {
 	t.Run("Env", func(t *testing.T) {
 		defer os.Unsetenv("NTT_TIMEOUT")
 
+		var (
+			v   float64
+			err error
+		)
+
 		suite := &ntt.Suite{}
-		v, err := suite.Timeout()
+		suite.SetErrorHandler(func(e error) { err = e })
+
+		err = nil
+		v = suite.Timeout()
 		assert.Nil(t, err)
 		assert.Zero(t, v)
 
 		os.Setenv("NTT_TIMEOUT", "0")
-		v, err = suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.Nil(t, err)
 		assert.Zero(t, v)
 
 		os.Setenv("NTT_TIMEOUT", "0.0")
-		v, err = suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.Nil(t, err)
 		assert.Zero(t, v)
 
 		os.Setenv("NTT_TIMEOUT", "23.5")
-		v, err = suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.Nil(t, err)
 		assert.Equal(t, float64(23.5), v)
 
 		os.Setenv("NTT_TIMEOUT", "some-string")
-		v, err = suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.NotNil(t, err)
 		assert.Zero(t, v)
 	})
 
 	t.Run("Root", func(t *testing.T) {
+
 		os.Unsetenv("NTT_TIMEOUT")
 		defer os.Unsetenv("NTT_TIMEOUT")
 
+		var (
+			v   float64
+			err error
+		)
+
 		suite := &ntt.Suite{}
+		suite.SetErrorHandler(func(e error) { err = e })
 
 		suite.SetRoot("./not_existent/")
-		v, err := suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.Nil(t, err)
 		assert.Zero(t, v)
 
 		suite.SetRoot(".")
 		f := suite.File("./package.yml")
 		f.SetBytes([]byte(`timeout: 23.5`))
-		v, err = suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.Nil(t, err)
 		assert.Equal(t, float64(23.5), v)
 
 		f.SetBytes([]byte(`timeout: hello master`))
-		v, err = suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.NotNil(t, err)
 
 		os.Setenv("NTT_TIMEOUT", "5.72")
-		v, err = suite.Timeout()
+		err = nil
+		v = suite.Timeout()
 		assert.Nil(t, err)
 		assert.Equal(t, float64(5.72), v)
 	})

--- a/internal/ntt/ntt.go
+++ b/internal/ntt/ntt.go
@@ -34,8 +34,23 @@ type Suite struct {
 	imports  []*File
 	testHook *File
 
+	// Error handling
+	eh func(error)
+
 	// Memoization
 	store memoize.Store
+}
+
+// SetErrorHandler sets function fn to be called, when an error occures.
+func (suite *Suite) SetErrorHandler(fn func(error)) {
+	suite.eh = fn
+}
+
+func (suite *Suite) reportError(err error) error {
+	if suite.eh != nil {
+		suite.eh(err)
+	}
+	return err
 }
 
 // Id returns the unique session id (aka NTT_SESSION_ID). This ID is the smallest


### PR DESCRIPTION
This commit introduces a side-channel for errors and makes ntt API use it.

The usual error handling feels awkward with lazy architectures. You never know what errors a function may return, because of the late computation. I'd like to explore if a side-channel for errors is beneficial for user experience.

Further, removing error return-values from function signatures is a good motivation for writing function, which always succeed.

