### PR TITLE
Replace paths with URIs

### DIFF
--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -12,7 +12,7 @@ import (
 
 func (s *Server) definition(ctx context.Context, params *protocol.DefinitionParams) (protocol.Definition, error) {
 	start := time.Now()
-	id, _ := s.suite.IdentifierAt(params.TextDocument.URI.SpanURI().Filename(), int(params.Position.Line)+1, int(params.Position.Character)+1)
+	id, _ := s.suite.IdentifierAt(string(params.TextDocument.URI.SpanURI()), int(params.Position.Line)+1, int(params.Position.Character)+1)
 	elapsed := time.Since(start)
 	log.Debug(fmt.Sprintf("Goto Definition took %s. IdentifierInfo: %#v", elapsed, id))
 

--- a/internal/lsp/general.go
+++ b/internal/lsp/general.go
@@ -27,7 +27,7 @@ func (s *Server) initialize(ctx context.Context, params *protocol.ParamInitializ
 	if len(s.pendingFolders) == 0 && params.RootURI != "" {
 		s.pendingFolders = []protocol.WorkspaceFolder{{
 			URI:  string(params.RootURI),
-			Name: path.Base(params.RootURI.SpanURI().Filename()),
+			Name: path.Base(string(params.RootURI.SpanURI())),
 		}}
 	}
 

--- a/internal/lsp/text_synchronization.go
+++ b/internal/lsp/text_synchronization.go
@@ -7,20 +7,21 @@ import (
 )
 
 func (s *Server) didOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
-	path := params.TextDocument.URI.SpanURI().Filename()
+	uri := string(params.TextDocument.URI.SpanURI())
+
 	// TODO(5nord) Sources might added multiple times.
 	if params.TextDocument.LanguageID == "ttcn3" {
-		s.suite.AddSources(path)
+		s.suite.AddSources(uri)
 	}
 
-	f := s.suite.File(path)
+	f := s.suite.File(uri)
 	f.SetBytes([]byte(params.TextDocument.Text))
 	s.Diagnose()
 	return nil
 }
 
 func (s *Server) didChange(ctx context.Context, params *protocol.DidChangeTextDocumentParams) error {
-	f := s.suite.File(params.TextDocument.URI.SpanURI().Filename())
+	f := s.suite.File(string(params.TextDocument.URI.SpanURI()))
 	for _, ch := range params.ContentChanges {
 		f.SetBytes([]byte(ch.Text))
 	}
@@ -32,7 +33,7 @@ func (s *Server) didSave(ctx context.Context, params *protocol.DidSaveTextDocume
 }
 
 func (s *Server) didClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
-	f := s.suite.File(params.TextDocument.URI.SpanURI().Filename())
+	f := s.suite.File(string(params.TextDocument.URI.SpanURI()))
 	f.Reset()
 	return nil
 }


### PR DESCRIPTION
The assumption all URI were `file://` failed, when using vscode remote-ssh-extension. This caused a panic from net/url package.

This commit removes all URI to path conversions.

