### PR TITLE
Add ttcn3_validator checks

### DIFF
--- a/internal/cmds/lint/error.go
+++ b/internal/cmds/lint/error.go
@@ -1,0 +1,50 @@
+package lint
+
+import (
+	"fmt"
+
+	"github.com/nokia/ntt/internal/loc"
+	"github.com/nokia/ntt/internal/ttcn3/ast"
+)
+
+type errNaming struct {
+	fset *loc.FileSet
+	node ast.Node
+	msg  string
+}
+
+func (e errNaming) Error() string {
+	return fmt.Sprintf("%s: error: %s", e.fset.Position(e.node.Pos()), e.msg)
+}
+
+type errLines struct {
+	fset  *loc.FileSet
+	node  ast.Node
+	lines int
+}
+
+func (e errLines) Error() string {
+	return fmt.Sprintf("%s: error: %q must not have more than %d lines (%d)",
+		e.fset.Position(e.node.Pos()), identName(e.node), style.MaxLines, e.lines)
+}
+
+type errBraces struct {
+	fset        *loc.FileSet
+	left, right ast.Node
+}
+
+func (e errBraces) Error() string {
+	return fmt.Sprintf("%s: error: braces must be in the same line or same column",
+		e.fset.Position(e.right.Pos()))
+}
+
+type errComplexity struct {
+	fset       *loc.FileSet
+	node       ast.Node
+	complexity int
+}
+
+func (e errComplexity) Error() string {
+	return fmt.Sprintf("%s: error: cyclomatic complexity of %q (%d) must not be higher than %d",
+		e.fset.Position(e.node.Pos()), identName(e.node), e.complexity, style.Complexity.Max)
+}

--- a/internal/cmds/lint/error.go
+++ b/internal/cmds/lint/error.go
@@ -14,17 +14,17 @@ var (
 	nolintRegex = regexp.MustCompile(`^[/*\s]*NOLINT\(([^\)]+)\)[/*\r\n\s]*$`)
 )
 
-type errNaming struct {
+type errPattern struct {
 	fset *loc.FileSet
 	node ast.Node
 	msg  string
 }
 
-func (e errNaming) Error() string {
+func (e errPattern) Error() string {
 	return fmt.Sprintf("%s: error: %s", e.fset.Position(e.node.Pos()), e.msg)
 }
 
-func (e errNaming) IsSilent() bool { return isSilent(e.node, "TemplateDef") }
+func (e errPattern) IsSilent() bool { return isSilent(e.node, "TemplateDef") }
 
 type errLines struct {
 	fset  *loc.FileSet

--- a/internal/cmds/lint/error.go
+++ b/internal/cmds/lint/error.go
@@ -62,6 +62,15 @@ func (e errComplexity) Error() string {
 
 func (e errComplexity) IsSilent() bool { return isSilent(e.node, "CodeStatistics.TooComplex") }
 
+type errMissingCaseElse struct {
+	fset *loc.FileSet
+	node ast.Node
+}
+
+func (e errMissingCaseElse) Error() string {
+	return fmt.Sprintf("%s: error: missing case else in select statement", e.fset.Position(e.node.Pos()))
+}
+
 func isSilent(n ast.Node, checks ...string) bool {
 	scanner := bufio.NewScanner(strings.NewReader(ast.FirstToken(n).Comments()))
 	for scanner.Scan() {

--- a/internal/cmds/lint/main.go
+++ b/internal/cmds/lint/main.go
@@ -1,8 +1,18 @@
 package lint
 
 import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/nokia/ntt/internal/loc"
 	"github.com/nokia/ntt/internal/ntt"
+	"github.com/nokia/ntt/internal/ttcn3/ast"
+	"github.com/nokia/ntt/internal/ttcn3/token"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -27,24 +37,490 @@ For information on writing a new check, see <TBD>.
 
 		RunE: lint,
 	}
+
+	config  string
+	regexes = make(map[string]*regexp.Regexp)
+
+	style = struct {
+		MaxLines      int  `yaml:"max_lines"`
+		AlignedBraces bool `yaml:"aligned_braces"`
+		Complexity    struct {
+			Max          int
+			IgnoreGuards bool `yaml:"ignore_guards"`
+		}
+		Naming struct {
+			Modules         map[string]string
+			Tests           map[string]string
+			Functions       map[string]string
+			Altsteps        map[string]string
+			Parameters      map[string]string
+			ComponentVars   map[string]string `yaml:"component_vars"`
+			PortTypes       map[string]string `yaml:"port_types"`
+			Ports           map[string]string
+			GlobalConsts    map[string]string `yaml:"global_consts"`
+			ComponentConsts map[string]string `yaml:"component_consts"`
+			Templates       map[string]string
+			Locals          map[string]string
+		}
+		Tags struct {
+			Tests map[string]string
+		}
+		Ignore struct {
+			Modules []string
+			Files   []string
+		}
+	}{}
 )
 
+func init() {
+	Command.PersistentFlags().StringVarP(&config, "config", "c", "", "path to YAML formatted file containing linter configuration")
+}
+
 func lint(cmd *cobra.Command, args []string) error {
+	if config != "" {
+		b, err := ioutil.ReadFile(config)
+		if err != nil {
+			return err
+		}
+
+		if err := yaml.UnmarshalStrict(b, &style); err != nil {
+			return err
+		}
+	}
+
+	if err := buildRegexCache(); err != nil {
+		return err
+	}
+
 	suite, err := ntt.NewFromArgs(args...)
 	if err != nil {
 		return err
 	}
-
 	files, err := suite.Files()
 	if err != nil {
 		return err
 	}
 
+	var wg sync.WaitGroup
+	wg.Add(len(files))
+
 	for i := range files {
-		info := suite.Parse(files[i])
-		if info.Err != nil {
+		go func(i int) {
+			defer wg.Done()
+
+			if isWhiteListed(style.Ignore.Files, files[i]) {
+				return
+			}
+
+			mod := suite.Parse(files[i])
+			if mod == nil || mod.Module == nil {
+				return
+			}
+
+			if isWhiteListed(style.Ignore.Modules, identName(mod.Module.Name)) {
+				return
+			}
+
+			stack := make([]ast.Node, 1, 64)
+			cc := make(map[ast.Node]int)
+			ccID := mod.Module.Name
+
+			ast.Inspect(mod.Module, func(n ast.Node) bool {
+				if n == nil {
+					stack = stack[:len(stack)-1]
+					return false
+				}
+
+				stack = append(stack, n)
+				fset := mod.FileSet
+
+				switch n := n.(type) {
+				case *ast.Module:
+					checkNaming(fset, n, style.Naming.Modules)
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+
+				case *ast.FuncDecl:
+					ccID = n.Name
+					cc[ccID] = 1 // Intial McCabe value
+
+					switch n.Kind.Kind {
+					case token.TESTCASE:
+						checkNaming(fset, n, style.Naming.Tests)
+					case token.FUNCTION:
+						checkNaming(fset, n, style.Naming.Functions)
+					case token.ALTSTEP:
+						checkNaming(fset, n, style.Naming.Altsteps)
+					}
+
+					checkLines(fset, n)
+
+				case *ast.FormalPar:
+					checkNaming(fset, n, style.Naming.Parameters)
+
+					// We do not descent any further,
+					// because we do not want to count
+					// cyclomatic complexity for default
+					// values.
+					return false
+
+				case *ast.PortTypeDecl:
+					checkNaming(fset, n, style.Naming.PortTypes)
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+
+				case *ast.Declarator:
+					if len(stack) <= 2 {
+						return true
+					}
+
+					// The parent of a declarator should
+					// always be a ValueDecl.  If not, we
+					// have some internal issues, it's okay
+					// to panic then.
+					parent := stack[len(stack)-2].(*ast.ValueDecl)
+					scope := stack[:len(stack)-2]
+
+					switch {
+					case isPort(parent):
+						checkNaming(fset, n, style.Naming.Ports)
+					case isConst(parent):
+						switch {
+						case inGlobalScope(scope):
+							checkNaming(fset, n, style.Naming.GlobalConsts)
+						case inComponentScope(scope):
+							checkNaming(fset, n, style.Naming.ComponentConsts)
+						}
+					case isVarTemplate(parent):
+						checkNaming(fset, n, style.Naming.Templates)
+					default:
+						switch {
+						case inComponentScope(scope):
+							checkNaming(fset, n, style.Naming.ComponentVars)
+						default:
+							checkNaming(fset, n, style.Naming.Locals)
+						}
+					}
+
+					return true
+
+				case *ast.TemplateDecl:
+					checkNaming(fset, n, style.Naming.Templates)
+
+				case *ast.BlockStmt:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.CompositeLiteral:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.ExceptExpr:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.SelectStmt:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.StructSpec:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.EnumSpec:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.ModuleParameterGroup:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.StructTypeDecl:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.EnumTypeDecl:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.ImportDecl:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.GroupDecl:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.WithSpec:
+					checkBraces(fset, n.LBrace.Pos(), n.RBrace.Pos())
+				case *ast.ParenExpr:
+					if n.LParen.Kind == token.LBRACE {
+						checkBraces(fset, n.LParen.Pos(), n.RParen.Pos())
+					}
+
+				case *ast.ModuleDef:
+					// Reset ID for counting cyclomatic complexity.
+					ccID = mod.Module.Name
+
+				case *ast.BinaryExpr:
+					if n.Op.Kind == token.AND || n.Op.Kind == token.OR {
+						cc[ccID]++
+					}
+
+				case *ast.IfStmt:
+					cc[ccID]++
+
+				case *ast.CaseClause:
+					// Do not count case else
+					if n.Case != nil {
+						cc[ccID]++
+					}
+
+				case *ast.CommClause:
+					if style.Complexity.IgnoreGuards {
+						return true
+					}
+
+					// Do not count else-guards
+					if n.Else.IsValid() {
+						return true
+					}
+					// Every AltGuard increases cyclomatic complexity.
+					cc[ccID]++
+
+					// Every AltGuard expressions also increases complexity.
+					if n.X != nil {
+						cc[ccID]++
+					}
+
+				}
+				return true
+			})
+
+			checkComplexity(mod.FileSet, cc)
+		}(i)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func checkNaming(fset *loc.FileSet, n ast.Node, patterns map[string]string) {
+	if len(patterns) == 0 {
+		return
+	}
+
+	s := identName(n)
+	for p, msg := range patterns {
+		expect := true
+		if strings.HasPrefix(p, "!") {
+			expect = false
+			p = p[1:]
+		}
+
+		if regexes[p].MatchString(s) != expect {
+			reportIssue(fset.Position(n.Pos()), msg)
+		}
+
+	}
+	return
+}
+
+func checkLines(fset *loc.FileSet, n ast.Node) {
+	if style.MaxLines == 0 {
+		return
+	}
+
+	begin := fset.Position(n.Pos())
+	end := fset.Position(n.End())
+	if end.Line-begin.Line > style.MaxLines {
+		reportIssue(begin, fmt.Sprintf("%q must not have more than %d lines", identName(n), style.MaxLines))
+	}
+
+}
+
+func checkBraces(fset *loc.FileSet, pos1 loc.Pos, pos2 loc.Pos) {
+	if !style.AlignedBraces {
+		return
+	}
+
+	p1 := fset.Position(pos1)
+	p2 := fset.Position(pos2)
+	if p1.Line != p2.Line && p1.Column != p2.Column {
+		reportIssue(p2, "Braces must be in the same line or same column")
+	}
+}
+
+func checkComplexity(fset *loc.FileSet, cc map[ast.Node]int) {
+	if style.Complexity.Max == 0 {
+		return
+	}
+
+	for n, v := range cc {
+		if v <= style.Complexity.Max {
+			continue
+		}
+
+		pos := fset.Position(n.Pos())
+		reportIssue(pos,
+			fmt.Sprintf("the cyclomatic complexity of %q (%d) must not be higher than %d",
+				identName(n), v, style.Complexity.Max))
+	}
+}
+
+func matchAny(patterns []string, s string) bool {
+	for _, p := range patterns {
+
+		expect := true
+		if strings.HasPrefix(p, "!") {
+			expect = false
+			p = p[1:]
+		}
+
+		if regexes[p].MatchString(s) == expect {
+			return true
+		}
+	}
+	return false
+}
+
+func reportIssue(pos loc.Position, msg string) {
+	fmt.Printf("%s: %s\n", pos.String(), msg)
+}
+
+func isWhiteListed(list []string, s string) bool {
+	if len(list) == 0 {
+		return false
+	}
+	return matchAny(list, s)
+}
+
+func inComponentScope(stack []ast.Node) bool {
+	for _, n := range stack {
+		if _, ok := n.(*ast.ComponentTypeDecl); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func inGlobalScope(stack []ast.Node) bool {
+	for _, n := range stack {
+		switch n.(type) {
+		case *ast.Module, *ast.ModuleDef, *ast.GroupDecl, *ast.ModuleParameterGroup:
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+func isPort(d *ast.ValueDecl) bool {
+	return d.Kind.Kind == token.PORT
+}
+
+func isConst(d *ast.ValueDecl) bool {
+	return d.Kind.Kind == token.CONST
+}
+
+func isVarTemplate(d *ast.ValueDecl) bool {
+	return d.TemplateRestriction != nil
+}
+
+func identName(n ast.Node) string {
+	switch n := n.(type) {
+	case *ast.CallExpr:
+		return identName(n.Fun)
+	case *ast.LengthExpr:
+		return identName(n.X)
+	case *ast.Ident:
+		return n.String()
+	case *ast.ParametrizedIdent:
+		return n.Ident.String()
+	case *ast.FuncDecl:
+		return n.Name.String()
+	case *ast.Module:
+		return n.Name.String()
+	case *ast.FormalPar:
+		return n.Name.String()
+	case *ast.PortTypeDecl:
+		return identName(n.Name)
+	case *ast.Declarator:
+		return n.Name.String()
+	case *ast.TemplateDecl:
+		return n.Name.String()
+	}
+	return "_"
+}
+
+func buildRegexCache() error {
+
+	for p := range style.Naming.Modules {
+		if err := cacheRegex(p); err != nil {
 			return err
 		}
+	}
+	for p := range style.Naming.Tests {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.Functions {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.Altsteps {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.Parameters {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.ComponentVars {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.PortTypes {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.Ports {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.GlobalConsts {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.ComponentConsts {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.Templates {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.Locals {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Tags.Tests {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for _, p := range style.Ignore.Modules {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for _, p := range style.Ignore.Files {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cacheRegex(p string) error {
+	if strings.HasPrefix(p, "!") {
+		p = p[1:]
+	}
+
+	if _, ok := regexes[p]; !ok {
+		r, err := regexp.Compile(p)
+		if err != nil {
+			return err
+		}
+		regexes[p] = r
 	}
 	return nil
 }

--- a/internal/cmds/lint/main.go
+++ b/internal/cmds/lint/main.go
@@ -191,7 +191,7 @@ func lint(cmd *cobra.Command, args []string) error {
 						}
 					case isVarTemplate(parent):
 						checkNaming(fset, n, style.Naming.Templates)
-					default:
+					case isVar(parent):
 						switch {
 						case inComponentScope(scope):
 							checkNaming(fset, n, style.Naming.ComponentVars)
@@ -404,6 +404,10 @@ func isPort(d *ast.ValueDecl) bool {
 
 func isConst(d *ast.ValueDecl) bool {
 	return d.Kind.Kind == token.CONST
+}
+
+func isVar(d *ast.ValueDecl) bool {
+	return !isVarTemplate(d) && d.Kind.Kind == token.VAR
 }
 
 func isVarTemplate(d *ast.ValueDecl) bool {

--- a/internal/cmds/lint/main.go
+++ b/internal/cmds/lint/main.go
@@ -41,6 +41,7 @@ For information on writing a new check, see <TBD>.
 
 	config  string
 	regexes = make(map[string]*regexp.Regexp)
+	issues  = 0
 
 	style = struct {
 		MaxLines        int  `yaml:"max_lines"`
@@ -290,7 +291,15 @@ func lint(cmd *cobra.Command, args []string) error {
 	}
 
 	wg.Wait()
-	return nil
+	switch issues {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("1 issue found.")
+	default:
+		return fmt.Errorf("%d issues found.", issues)
+	}
+
 }
 
 func checkNaming(fset *loc.FileSet, n ast.Node, patterns map[string]string) {
@@ -408,6 +417,7 @@ func report(e error) {
 		return
 	}
 
+	issues++
 	fmt.Println(e.Error())
 }
 

--- a/internal/cmds/lint/main.go
+++ b/internal/cmds/lint/main.go
@@ -55,6 +55,7 @@ For information on writing a new check, see <TBD>.
 			Altsteps        map[string]string
 			Parameters      map[string]string
 			ComponentVars   map[string]string `yaml:"component_vars"`
+			VarTemplates    map[string]string `yaml:"var_templates"`
 			PortTypes       map[string]string `yaml:"port_types"`
 			Ports           map[string]string
 			GlobalConsts    map[string]string `yaml:"global_consts"`
@@ -190,7 +191,7 @@ func lint(cmd *cobra.Command, args []string) error {
 							checkNaming(fset, n, style.Naming.ComponentConsts)
 						}
 					case isVarTemplate(parent):
-						checkNaming(fset, n, style.Naming.Templates)
+						checkNaming(fset, n, style.Naming.VarTemplates)
 					case isVar(parent):
 						switch {
 						case inComponentScope(scope):
@@ -493,6 +494,11 @@ func buildRegexCache() error {
 		}
 	}
 	for p := range style.Naming.Templates {
+		if err := cacheRegex(p); err != nil {
+			return err
+		}
+	}
+	for p := range style.Naming.VarTemplates {
 		if err := cacheRegex(p); err != nil {
 			return err
 		}

--- a/internal/cmds/lint/main.go
+++ b/internal/cmds/lint/main.go
@@ -3,7 +3,6 @@ package lint
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -368,7 +367,7 @@ func report(e error) {
 		return
 	}
 
-	fmt.Fprintln(os.Stderr, e.Error())
+	fmt.Println(e.Error())
 }
 
 func isWhiteListed(list []string, s string) bool {

--- a/internal/cmds/lint/main.go
+++ b/internal/cmds/lint/main.go
@@ -27,11 +27,79 @@ considered "bad style".
 Lint's exit code is non-zero for erroneous invocation of the tool or if a
 problem was reported.
 
-To list the available checks, run "ntt lint help":
 
-    <none>
+Formatting Checks
 
-For details and flags of a particular check, run "ntt lint help <check>".
+    max_lines          Number of lines a behaviour body must not exceed.
+    aligned_braces     Braces must be in the same column or same line.
+    require_case_else  Every select-statement must have one case-else.
+
+
+Cyclomatic Complexity Checks
+
+    complexity.max           Cyclomatic complexity muss not exceed.
+    complexity.ignore_guards Ignore complexity of alt- and interleave guards
+
+
+Naming Convention Checks
+
+    naming.modules            Checks for module identifiers.
+    naming.tests              Checks for test-case identifier.
+    naming.functions          Checks for function identifiers.
+    naming.altsteps           Checks for altstep identifiers.
+    naming.parameters         Checks for parameter identifiers.
+    naming.component_vars     Checks for component variable identifiers.
+    naming.var_templates      Checks for variable template identifiers.
+    naming.port_types         Checks for port type identifiers.
+    naming.ports              Checks for port instance identifiers.
+    naming.global_consts      Checks for global constant identifiers.
+    naming.component_consts   Checks for component scoped constant identifiers.
+    naming.templates          Checks for constant template identifiers.
+    naming.locals             Checks for local variable identifiers.
+
+    tags.tests                Checks for test-case tags.
+
+
+White-Listing
+
+    ignore.modules    Ignore modules
+    ignore.files      Ignore files
+
+
+Example configuration file:
+
+	aligned_braces: true
+	require_case_else: true
+	max_lines: 40
+
+	complexity:
+	  max: 15
+	  ignore_guards: true
+
+	tags:
+	  tests:
+	    "@author": "testcases must have a @author tag"
+
+	naming:
+	  tests:
+	    # An exlamation mark inverts the match.
+	    "!.{130,}": "testcase identifiers must not be longer than 130 characters"
+
+	  functions:
+	    "^[a-z]"      : "function identifiers must begin with a lower case letter"
+	    "!^(f|func)_" : "function identifiers must not begin with f_ or func_"
+
+	  global_consts:
+	    "^[A-Z0-9_]+$": "global constants must be UPPER_CASE"
+
+	ignore:
+	  modules:
+	    # Ignore generated modules
+	    - "^Protobuf_.+$"
+
+	  files:
+	    # Ignore all files from generated folders
+	    - "generated/"
 
 For information on writing a new check, see <TBD>.
 `,

--- a/internal/ttcn3/ast/ast.go
+++ b/internal/ttcn3/ast/ast.go
@@ -118,7 +118,7 @@ func (x Token) MarshalJSON() ([]byte, error) {
 	return json.Marshal(strs)
 }
 
-func (t *Token) LastTok() *Token { return t }
+func (t Token) LastTok() *Token { return &t }
 
 // Trivia represent the parts of the source text that are largely insignificant
 // for normal understanding of the code, such as whitespace, comments, and

--- a/internal/ttcn3/ast/ast.go
+++ b/internal/ttcn3/ast/ast.go
@@ -1416,8 +1416,8 @@ func (x *FormalPar) Pos() loc.Pos {
 	return x.Type.Pos()
 }
 
-func (x *WithSpec) Pos() loc.Pos        { return x.LastTok().End() }
-func (x *WithStmt) Pos() loc.Pos        { return x.LastTok().End() }
+func (x *WithSpec) Pos() loc.Pos        { return x.Tok.Pos() }
+func (x *WithStmt) Pos() loc.Pos        { return x.Kind.Pos() }
 func (x *LanguageSpec) End() loc.Pos    { return x.LastTok().End() }
 func (x *RestrictionSpec) End() loc.Pos { return x.LastTok().End() }
 func (x *RunsOnSpec) End() loc.Pos      { return x.LastTok().End() }

--- a/internal/ttcn3/ast/utils.go
+++ b/internal/ttcn3/ast/utils.go
@@ -1,0 +1,213 @@
+package ast
+
+import (
+	"fmt"
+
+	"github.com/nokia/ntt/internal/ttcn3/token"
+)
+
+// First returns the first valid token of a syntax tree
+func FirstToken(n Node) *Token {
+	switch n := n.(type) {
+	case Token:
+		return &n
+	case *ErrorNode:
+		return &n.From
+	case *Ident:
+		return &n.Tok
+	case *ParametrizedIdent:
+		return FirstToken(n.Ident)
+	case *ValueLiteral:
+		return &n.Tok
+	case *CompositeLiteral:
+		return &n.LBrace
+	case *UnaryExpr:
+		return &n.Op
+	case *BinaryExpr:
+		if n.X != nil {
+			return FirstToken(n.X)
+		}
+		return &n.Op
+
+	case *ParenExpr:
+		return &n.LParen
+	case *SelectorExpr:
+		return FirstToken(n.X)
+	case *IndexExpr:
+		if n.X != nil {
+			return FirstToken(n.X)
+		}
+		return &n.LBrack
+	case *CallExpr:
+		return FirstToken(n.Fun)
+	case *LengthExpr:
+		if n.X != nil {
+			return FirstToken(n.X)
+		}
+		return &n.Len
+	case *RedirectExpr:
+		return FirstToken(n.X)
+	case *TemplateDecl:
+		return FirstToken(&n.RestrictionSpec)
+	case *ValueExpr:
+		return FirstToken(n.X)
+	case *ParamExpr:
+		return FirstToken(n.X)
+	case *FromExpr:
+		return &n.Kind
+	case *ModifiesExpr:
+		return &n.Tok
+	case *RegexpExpr:
+		return &n.Tok
+	case *PatternExpr:
+		return &n.Tok
+	case *DecmatchExpr:
+		return &n.Tok
+	case *DecodedExpr:
+		return &n.Tok
+	case *DefKindExpr:
+		return &n.Kind
+	case *ExceptExpr:
+		return FirstToken(n.X)
+	case *BlockStmt:
+		return &n.LBrace
+	case *DeclStmt:
+		return FirstToken(n.Decl)
+	case *ExprStmt:
+		return FirstToken(n.Expr)
+	case *BranchStmt:
+		return &n.Tok
+	case *ReturnStmt:
+		return &n.Tok
+	case *CallStmt:
+		return FirstToken(n.Stmt)
+	case *AltStmt:
+		return &n.Tok
+	case *ForStmt:
+		return &n.Tok
+	case *WhileStmt:
+		return &n.Tok
+	case *DoWhileStmt:
+		return &n.DoTok
+	case *IfStmt:
+		return &n.Tok
+	case *SelectStmt:
+		return &n.Tok
+	case *CaseClause:
+		return &n.Tok
+	case *CommClause:
+		return &n.LBrack
+	case *Field:
+		if n.DefaultTok.IsValid() {
+			return &n.DefaultTok
+		}
+		return FirstToken(n.Type)
+	case *RefSpec:
+		return FirstToken(n.X)
+	case *StructSpec:
+		return &n.Kind
+	case *ListSpec:
+		return &n.Kind
+	case *EnumSpec:
+		return &n.Tok
+	case *BehaviourSpec:
+		return &n.Kind
+	case *ValueDecl:
+		if n.Kind.IsValid() {
+			return &n.Kind
+		}
+		return FirstToken(n.Type)
+
+	case *Declarator:
+		if n.Name != nil {
+			return FirstToken(n.Name)
+		}
+		if len(n.ArrayDef) > 0 {
+			return FirstToken(n.ArrayDef[0])
+		}
+		if n.AssignTok.IsValid() {
+			return &n.AssignTok
+		}
+		if n.Value != nil {
+			return FirstToken(n.Value)
+		}
+		panic("ast.Node contains no tokens. This is probably a parser error")
+
+	case *ModuleParameterGroup:
+		return &n.Tok
+
+	case *FuncDecl:
+		if n.External.Kind == token.EXTERNAL {
+			return &n.External
+		}
+		return &n.Kind
+
+	case *SignatureDecl:
+		return &n.Tok
+	case *SubTypeDecl:
+		return &n.TypeTok
+	case *StructTypeDecl:
+		return &n.TypeTok
+	case *EnumTypeDecl:
+		return &n.TypeTok
+	case *BehaviourTypeDecl:
+		return &n.TypeTok
+	case *PortTypeDecl:
+		return &n.TypeTok
+	case *PortAttribute:
+		return &n.Kind
+	case *PortMapAttribute:
+		return &n.MapTok
+	case *ComponentTypeDecl:
+		return &n.TypeTok
+	case *Module:
+		return &n.Tok
+	case *ModuleDef:
+		if n.Visibility.IsValid() {
+			return &n.Visibility
+		}
+		return FirstToken(n.Def)
+	case *ControlPart:
+		return &n.Tok
+	case *ImportDecl:
+		return &n.ImportTok
+	case *GroupDecl:
+		return &n.Tok
+	case *FriendDecl:
+		return &n.FriendTok
+	case *LanguageSpec:
+		return &n.Tok
+	case *RestrictionSpec:
+		if n.TemplateTok.IsValid() {
+			return &n.TemplateTok
+		}
+		return &n.Tok
+	case *RunsOnSpec:
+		return &n.RunsTok
+	case *SystemSpec:
+		return &n.Tok
+	case *MtcSpec:
+		return &n.Tok
+	case *ReturnSpec:
+		return &n.Tok
+	case *FormalPars:
+		return &n.LParen
+	case *FormalPar:
+		if n.Direction.IsValid() {
+			return &n.Direction
+		}
+		if n.TemplateRestriction != nil {
+			return FirstToken(n.TemplateRestriction)
+		}
+		if n.Modif.IsValid() {
+			return &n.Modif
+		}
+		return FirstToken(n.Type)
+	case *WithSpec:
+		return &n.Tok
+	case *WithStmt:
+		return &n.Kind
+	default:
+		panic(fmt.Sprintf("unknown ast.Node: %T", n))
+	}
+}

--- a/internal/ttcn3/parser/parser.go
+++ b/internal/ttcn3/parser/parser.go
@@ -1916,9 +1916,9 @@ func (p *parser) parseValueDecl() *ast.ValueDecl {
 }
 
 func (p *parser) parseRestrictionSpec() *ast.RestrictionSpec {
-	x := new(ast.RestrictionSpec)
 	switch p.tok {
 	case token.TEMPLATE:
+		x := new(ast.RestrictionSpec)
 		x.TemplateTok = p.consume()
 		if p.tok != token.LPAREN {
 			return nil
@@ -1927,11 +1927,15 @@ func (p *parser) parseRestrictionSpec() *ast.RestrictionSpec {
 		x.LParen = p.consume()
 		x.Tok = p.consume()
 		x.RParen = p.expect(token.RPAREN)
+		return x
 
 	case token.OMIT, token.VALUE, token.PRESENT:
+		x := new(ast.RestrictionSpec)
 		x.Tok = p.consume()
+		return x
+	default:
+		return nil
 	}
-	return x
 }
 
 func (p *parser) parseDeclList() (list []ast.Decl) {

--- a/internal/ttcn3/parser/parser.go
+++ b/internal/ttcn3/parser/parser.go
@@ -1920,13 +1920,11 @@ func (p *parser) parseRestrictionSpec() *ast.RestrictionSpec {
 	case token.TEMPLATE:
 		x := new(ast.RestrictionSpec)
 		x.TemplateTok = p.consume()
-		if p.tok != token.LPAREN {
-			return nil
+		if p.tok == token.LPAREN {
+			x.LParen = p.consume()
+			x.Tok = p.consume()
+			x.RParen = p.expect(token.RPAREN)
 		}
-
-		x.LParen = p.consume()
-		x.Tok = p.consume()
-		x.RParen = p.expect(token.RPAREN)
 		return x
 
 	case token.OMIT, token.VALUE, token.PRESENT:


### PR DESCRIPTION
ttcn3_validator is a Nokia internal linter tool for TTCN-3. This commits
add its functionality to ntt lint tool. Available checks:

* aligned braces
* maximum number of lines of lines in behaviour bodies
* maximum cyclomatic complexity
* naming rules
* TTCN-3 tags