### PR TITLE
Add new command report

### DIFF
--- a/cmd/ntt/main.go
+++ b/cmd/ntt/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nokia/ntt/internal/cmds/langserver"
 	"github.com/nokia/ntt/internal/cmds/lint"
 	"github.com/nokia/ntt/internal/cmds/list"
+	"github.com/nokia/ntt/internal/cmds/report"
 	"github.com/nokia/ntt/internal/cmds/tags"
 )
 
@@ -81,15 +82,18 @@ var (
 func init() {
 	session.SharedDir = "/tmp/k3"
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
-	rootCmd.PersistentFlags().BoolVarP(&ShSetup, "sh", "", false, "output test suite data for shell consumption")
-	rootCmd.PersistentFlags().BoolVarP(&JSON, "json", "", false, "output in JSON format")
 	rootCmd.PersistentFlags().StringVarP(&cpuprofile, "cpuprofile", "", "", "write cpu profile to `file`")
 	rootCmd.AddCommand(showCmd)
+
+	showCmd.PersistentFlags().BoolVarP(&ShSetup, "sh", "", false, "output test suite data for shell consumption")
+	showCmd.PersistentFlags().BoolVarP(&JSON, "json", "", false, "output in JSON format")
 	rootCmd.AddCommand(dump.Command)
 	rootCmd.AddCommand(langserver.Command)
 	rootCmd.AddCommand(lint.Command)
 	rootCmd.AddCommand(list.Command)
 	rootCmd.AddCommand(tags.Command)
+	rootCmd.AddCommand(report.Command)
+
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nokia/ntt
 
-go 1.11
+go 1.12
 
 require (
 	github.com/golang/protobuf v1.4.2
@@ -13,6 +13,6 @@ require (
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/protobuf v1.25.0
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -327,6 +328,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/internal/cmds/report/loads.go
+++ b/internal/cmds/report/loads.go
@@ -1,0 +1,8 @@
+// +build windows
+
+//
+package report
+
+func loads() [3]float64 {
+	return [3]float64{}
+}

--- a/internal/cmds/report/loads_unix.go
+++ b/internal/cmds/report/loads_unix.go
@@ -1,0 +1,17 @@
+// +build !windows
+
+//
+package report
+
+import "syscall"
+
+func loads() [3]float64 {
+	var si syscall.Sysinfo_t
+	syscall.Sysinfo(&si)
+	var a = [3]float64{
+		float64(si.Loads[0]) / 65536.0,
+		float64(si.Loads[1]) / 65536.0,
+		float64(si.Loads[2]) / 65536.0,
+	}
+	return a
+}

--- a/internal/cmds/report/main.go
+++ b/internal/cmds/report/main.go
@@ -125,8 +125,9 @@ JSON template:
 const (
 	summaryTemplate = `{{bold}}==================================  Summary  =================================={{off}}
 {{range .Tests.NotPassed}}{{ printf "%-10s %s" .Verdict .Name  | colorize }}
+{{else}}{{if eq (len .Tests) 0}}{{orange}}{{bold}}WARNING: No matching test cases found!{{off}}
 {{else}}{{green}}all tests have passed{{off}}
-{{end}}
+{{end}}{{end}}
 {{len .Tests}} test cases took {{bold}}{{.Tests.Duration}}{{off}} to execute (total runs: {{len .Runs}}
 {{- with .Tests.Failed}}, {{red}}not passed: {{len .}}{{off}}{{end}}
 {{- with .Tests.Unstable}}, {{orange}}unstable: {{len .}}{{off}}{{end}})
@@ -244,9 +245,11 @@ var funcMap = template.FuncMap{
 		none := regexp.MustCompile(`(?i)\bnone`)
 		inconc := regexp.MustCompile(`(?i)\binconc`)
 
-		re := regexp.MustCompile(`(?i)\b(pass\w*|fail\w*|\w*error\w*|unstable|none|inconc\w*)\b`)
+		re := regexp.MustCompile(`(?i)\b(NORUN|pass\w*|fail\w*|\w*error\w*|unstable|none|inconc\w*)\b`)
 		return re.ReplaceAllStringFunc(s, func(s string) string {
 			switch {
+			case s == "NORUN":
+				return "[38;5;208;1m" + s + "[0m"
 			case pass.MatchString(s):
 				return "[32;1m" + s + "[0m"
 			case fail.MatchString(s):

--- a/internal/cmds/report/main.go
+++ b/internal/cmds/report/main.go
@@ -1,0 +1,154 @@
+package report
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/nokia/ntt/internal/ntt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	Command = &cobra.Command{
+		Use:   "report",
+		Short: "show test suite information",
+		Long: `show test suite information
+`,
+		RunE: report,
+	}
+
+	w = bufio.NewWriter(os.Stdout)
+
+	useJSON  = false
+	useJUnit = false
+
+	templateText = ""
+)
+
+const (
+	summaryTemplate = `{{bold}}==================================  Summary  =================================={{off}}
+{{range .Tests.NotPassed}}{{ printf "%-10s %s" .Verdict .Name  | colorize }}
+{{else}}{{green}}all tests have passed{{off}}
+{{end}}
+{{len .Tests}} test cases took {{bold}}{{.Duration}}{{off}} to execute (total runs: {{len .Runs}}
+{{- with .Tests.Failed}}, {{red}}not passed: {{len .}}{{off}}{{end}}
+{{- with .Tests.Unstable}}, {{orange}}unstable: {{len .}}{{off}}{{end}})
+{{bold}}==============================================================================={{off}}
+
+{{ printf "%s (±%s)" .Average .Deviation | printf "Average  : %-30s CPU cores      : " }}{{printf "%d" .Cores}}
+{{ printf "Shortest : %-30s Parallel tests : %d" .Shortest.Duration .MaxJobs }}
+{{ printf "Longest  : %-30s Load limit     : %d" .Longest.Duration .MaxLoad}}
+{{ printf "Total    : %-30s Load           : %.2f" .Total .Loads}}
+
+{{bold}}==============================================================================={{off}}
+{{bold}}Final Result: {{.Tests.Result | colorize}}{{off}}
+{{bold}}==============================================================================={{off}}
+`
+
+	junitTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>{{range .Tests.Modules}}
+    <testsuite name="{{.Name}}" tests="{{len .Tests}}" failures="$failures" errors="" time="{{.Duration}}">
+	{{range .Tests}}<testcase name="{{.Testcase}}" time="{{.Duration}}">
+	{{if ne .Verdict "pass"}}<failure>Verdict: {{.Verdict}}
+		{{.Reason | html }}</failure>
+	{{end}}</testcase>
+	{{end}}</testsuite>
+{{end}}</testsuites>
+`
+)
+
+func report(cmd *cobra.Command, args []string) error {
+
+	suite, err := ntt.NewFromArgs(args...)
+	if err != nil {
+		return err
+	}
+
+	report, err := NewReport(suite)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case useJSON:
+		return reportJSON(report)
+	case useJUnit:
+		return reportTemplate(report, junitTemplate)
+	default:
+		return reportTemplate(report, templateText)
+	}
+}
+
+func reportJSON(report *Report) error {
+	b, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	fmt.Print(string(b))
+	return nil
+}
+
+func reportTemplate(report *Report, text string) error {
+	tmpl, err := template.New("ntt report").Funcs(funcMap).Parse(text)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(os.Stdout, report)
+}
+
+var funcMap = template.FuncMap{
+	"green": func() string {
+		return "[32;1m"
+	},
+	"red": func() string {
+		return "[31;1m"
+	},
+	"orange": func() string {
+		return "[38;5;208;1m"
+	},
+	"bold": func() string {
+		return "[1m"
+	},
+	"off": func() string {
+		return "[0m"
+	},
+
+	"colorize": func(s string) string {
+		pass := regexp.MustCompile(`(?i)pass`)
+		fail := regexp.MustCompile(`(?i)fail|error`)
+		unstable := regexp.MustCompile(`(?i)unstable`)
+		none := regexp.MustCompile(`(?i)\bnone`)
+		inconc := regexp.MustCompile(`(?i)\binconc`)
+
+		re := regexp.MustCompile(`(?i)\b(pass\w*|fail\w*|\w*error\w*|unstable|none|inconc\w*)\b`)
+		return re.ReplaceAllStringFunc(s, func(s string) string {
+			switch {
+			case pass.MatchString(s):
+				return "[32;1m" + s + "[0m"
+			case fail.MatchString(s):
+				return "[31;1m" + s + "[0m"
+			case unstable.MatchString(s):
+				return "[38;5;208;1m" + s + "[0m"
+			case inconc.MatchString(s) || none.MatchString(s):
+				return "[38;5;201;1m" + s + "[0m"
+			default:
+				return s
+			}
+		})
+	},
+	"join": func(sep string, v interface{}) string {
+		return strings.Join(v.([]string), sep)
+	},
+}
+
+func init() {
+	Command.PersistentFlags().BoolVarP(&useJSON, "json", "", false, "output report in JSON format")
+	Command.PersistentFlags().BoolVarP(&useJUnit, "junit", "", false, "output report in Junit format")
+	Command.PersistentFlags().StringVarP(&templateText, "template", "t", summaryTemplate, "output report with custom template")
+}

--- a/internal/cmds/report/report.go
+++ b/internal/cmds/report/report.go
@@ -1,0 +1,206 @@
+package report
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/nokia/ntt/internal/ntt"
+	"github.com/nokia/ntt/internal/results"
+	"golang.org/x/sync/errgroup"
+)
+
+type Report struct {
+	Collection
+	suite *ntt.Suite
+	db    results.DB
+	Cores int
+	Loads [3]float64
+}
+
+func NewReport(suite *ntt.Suite) (*Report, error) {
+	db, err := suite.LatestResults()
+	if err != nil {
+		return nil, err
+	}
+
+	name, _ := suite.Name()
+
+	return &Report{
+		Collection: *NewCollection(name, results.FinalVerdicts(db.Runs)...),
+		suite:      suite,
+		db:         *db,
+		Cores:      runtime.NumCPU(),
+		Loads:      loads(),
+	}, nil
+}
+
+func (r *Report) LineCount() (int, error) {
+	files, err := r.suite.Files()
+	if err != nil {
+		return -1, err
+	}
+
+	var sum int32
+	g := new(errgroup.Group)
+	for _, file := range files {
+		file := file // https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() error {
+			var err error
+
+			buf := make([]byte, 32*1024)
+			count := int32(0)
+			lineSep := []byte{'\n'}
+			r, err := os.Open(file)
+			if err != nil {
+				return err
+			}
+			for {
+				c, err := r.Read(buf)
+				atomic.AddInt32(&count, int32(bytes.Count(buf[:c], lineSep)))
+
+				if err != nil {
+					if err == io.EOF {
+						err = nil
+					}
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	return int(sum), g.Wait()
+}
+
+func (r *Report) Runs() *Collection {
+	name, _ := r.suite.Name()
+	return NewCollection(name, r.db.Runs...)
+}
+
+type Collection struct {
+	Name  string
+	Tests []Run
+}
+
+func NewCollection(name string, runs ...results.Run) *Collection {
+	c := &Collection{
+		Name:  name,
+		Tests: make([]Run, len(runs)),
+	}
+
+	for i, r := range runs {
+		c.Tests[i] = Run{r}
+	}
+	return c
+}
+
+func (c *Collection) runs() []results.Run {
+	ret := make([]results.Run, len(c.Tests))
+	for i, r := range c.Tests {
+		ret[i] = r.Run
+	}
+	return ret
+}
+
+func (c *Collection) Total() time.Duration {
+	return results.Total(c.runs())
+}
+
+func (c *Collection) Duration() time.Duration {
+	return results.Duration(c.runs())
+}
+
+func (c *Collection) Shortest() Run {
+	return Run{results.Shortest(c.runs())}
+}
+
+func (c *Collection) Longest() Run {
+	return Run{results.Longest(c.runs())}
+}
+
+func (c *Collection) Average() time.Duration {
+	return results.Average(results.Durations(c.runs()))
+}
+
+func (c *Collection) Deviation() time.Duration {
+	return results.Deviation(results.Durations(c.runs()))
+}
+
+func (c Collection) Modules() []*Collection {
+	suites := make(map[string]*Collection)
+	for _, r := range c.Tests {
+		c, ok := suites[r.Module()]
+		if !ok {
+			c = NewCollection(r.Module())
+			suites[r.Module()] = c
+		}
+		c.Tests = append(c.Tests, r)
+	}
+
+	ret := make([]*Collection, 0, len(suites))
+	for _, v := range suites {
+		ret = append(ret, v)
+	}
+	return ret
+}
+
+func (c Collection) NotPassed() []Run {
+	return c.filter(func(s string) bool { return s != "pass" })
+}
+
+func (c Collection) Failed() []Run {
+	return c.filter(func(s string) bool { return s != "pass" && s != "unstable" })
+}
+
+func (c Collection) Unstable() []Run {
+	return c.filter(func(s string) bool { return s == "unstable" })
+}
+
+func (c Collection) filter(f func(s string) bool) []Run {
+	ret := make([]Run, 0, len(c.Tests))
+	for _, r := range c.Tests {
+		if f(r.Verdict) {
+			ret = append(ret, r)
+		}
+	}
+	return ret
+}
+
+func (c Collection) Result() string {
+	switch {
+	case len(c.Tests) == 0:
+		return "NORUN"
+
+	case len(c.Failed()) != 0:
+		return "FAILED"
+
+	case len(c.Unstable()) != 0:
+		return "UNSTABLE"
+
+	case len(c.Failed()) == 0 && len(c.Unstable()) == 0:
+		return "PASSED"
+
+	default:
+		return "FAILED"
+	}
+}
+
+type Run struct{ results.Run }
+
+func (r Run) Module() string {
+	if f := strings.Split(r.Name, "."); len(f) == 2 {
+		return f[0]
+	}
+	return ""
+}
+
+func (r Run) Testcase() string {
+	f := strings.Split(r.Name, ".")
+	return f[len(f)-1]
+}

--- a/internal/cmds/report/report.go
+++ b/internal/cmds/report/report.go
@@ -31,14 +31,20 @@ func NewReport(suite *ntt.Suite) (*Report, error) {
 		return nil, err
 	}
 
-	name, _ := suite.Name()
-	return &Report{
-		Collection: *NewCollection(name, db.Runs...),
-		suite:      suite,
-		db:         *db,
-		Cores:      runtime.NumCPU(),
-		Loads:      loads(),
-	}, nil
+	r := Report{
+		suite: suite,
+		Cores: runtime.NumCPU(),
+		Loads: loads(),
+	}
+
+	r.Name, _ = suite.Name()
+
+	if db != nil {
+		r.db = *db
+		r.Collection = *NewCollection(r.Name, db.Runs...)
+	}
+
+	return &r, nil
 }
 
 func (r *Report) Getenv(s string) string {

--- a/internal/cmds/report/report.go
+++ b/internal/cmds/report/report.go
@@ -3,8 +3,11 @@ package report
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -29,9 +32,8 @@ func NewReport(suite *ntt.Suite) (*Report, error) {
 	}
 
 	name, _ := suite.Name()
-
 	return &Report{
-		Collection: *NewCollection(name, results.FinalVerdicts(db.Runs)...),
+		Collection: *NewCollection(name, db.Runs...),
 		suite:      suite,
 		db:         *db,
 		Cores:      runtime.NumCPU(),
@@ -39,6 +41,18 @@ func NewReport(suite *ntt.Suite) (*Report, error) {
 	}, nil
 }
 
+func (r *Report) Getenv(s string) string {
+	env, _ := r.suite.Getenv(s)
+	return env
+}
+
+func (r *Report) Environ() []string {
+	env := os.Environ()
+	env2, _ := r.suite.Environ()
+	env = append(env, env2...)
+	sort.Strings(env)
+	return env
+}
 func (r *Report) LineCount() (int, error) {
 	files, err := r.suite.Files()
 	if err != nil {
@@ -53,7 +67,6 @@ func (r *Report) LineCount() (int, error) {
 			var err error
 
 			buf := make([]byte, 32*1024)
-			count := int32(0)
 			lineSep := []byte{'\n'}
 			r, err := os.Open(file)
 			if err != nil {
@@ -61,7 +74,7 @@ func (r *Report) LineCount() (int, error) {
 			}
 			for {
 				c, err := r.Read(buf)
-				atomic.AddInt32(&count, int32(bytes.Count(buf[:c], lineSep)))
+				atomic.AddInt32(&sum, int32(bytes.Count(buf[:c], lineSep)))
 
 				if err != nil {
 					if err == io.EOF {
@@ -70,77 +83,54 @@ func (r *Report) LineCount() (int, error) {
 					return err
 				}
 			}
-
-			return nil
 		})
 	}
 
 	return int(sum), g.Wait()
 }
 
-func (r *Report) Runs() *Collection {
-	name, _ := r.suite.Name()
-	return NewCollection(name, r.db.Runs...)
+func (r *Report) MaxJobs() int {
+	return r.db.MaxJobs
+}
+
+func (r *Report) MaxLoad() int {
+	return r.db.MaxLoad
 }
 
 type Collection struct {
-	Name  string
-	Tests []Run
+	Name string
+	runs RunSlice
 }
 
 func NewCollection(name string, runs ...results.Run) *Collection {
 	c := &Collection{
-		Name:  name,
-		Tests: make([]Run, len(runs)),
+		Name: name,
+		runs: make(RunSlice, len(runs)),
 	}
 
 	for i, r := range runs {
-		c.Tests[i] = Run{r}
+		c.runs[i] = Run{r}
 	}
 	return c
 }
 
-func (c *Collection) runs() []results.Run {
-	ret := make([]results.Run, len(c.Tests))
-	for i, r := range c.Tests {
-		ret[i] = r.Run
-	}
-	return ret
+func (c Collection) Runs() RunSlice {
+	return c.runs
 }
 
-func (c *Collection) Total() time.Duration {
-	return results.Total(c.runs())
-}
-
-func (c *Collection) Duration() time.Duration {
-	return results.Duration(c.runs())
-}
-
-func (c *Collection) Shortest() Run {
-	return Run{results.Shortest(c.runs())}
-}
-
-func (c *Collection) Longest() Run {
-	return Run{results.Longest(c.runs())}
-}
-
-func (c *Collection) Average() time.Duration {
-	return results.Average(results.Durations(c.runs()))
-}
-
-func (c *Collection) Deviation() time.Duration {
-	return results.Deviation(results.Durations(c.runs()))
+func (c Collection) Tests() RunSlice {
+	return NewRunSlice(results.FinalVerdicts(c.runs.asResultsRun()))
 }
 
 func (c Collection) Modules() []*Collection {
 	suites := make(map[string]*Collection)
-	for _, r := range c.Tests {
+	for _, r := range c.runs {
 		c, ok := suites[r.Module()]
 		if !ok {
 			c = NewCollection(r.Module())
-			suites[r.Module()] = c
 		}
-		c.Tests = append(c.Tests, r)
+		c.runs = append(c.runs, r)
+		suites[r.Module()] = c
 	}
 
 	ret := make([]*Collection, 0, len(suites))
@@ -150,21 +140,82 @@ func (c Collection) Modules() []*Collection {
 	return ret
 }
 
-func (c Collection) NotPassed() []Run {
-	return c.filter(func(s string) bool { return s != "pass" })
+type RunSlice []Run
+
+func NewRunSlice(runs []results.Run) RunSlice {
+	ret := make(RunSlice, len(runs))
+	for i, r := range runs {
+		ret[i] = Run{r}
+	}
+	return ret
 }
 
-func (c Collection) Failed() []Run {
-	return c.filter(func(s string) bool { return s != "pass" && s != "unstable" })
+func (rs RunSlice) Total() time.Duration {
+	return results.Total(rs.asResultsRun())
 }
 
-func (c Collection) Unstable() []Run {
-	return c.filter(func(s string) bool { return s == "unstable" })
+func (rs RunSlice) Duration() time.Duration {
+	return results.Duration(rs.asResultsRun())
 }
 
-func (c Collection) filter(f func(s string) bool) []Run {
-	ret := make([]Run, 0, len(c.Tests))
-	for _, r := range c.Tests {
+func (rs RunSlice) First() Run {
+	return Run{results.First(rs.asResultsRun())}
+}
+
+func (rs RunSlice) Last() Run {
+	return Run{results.Last(rs.asResultsRun())}
+}
+
+func (rs RunSlice) Shortest() Run {
+	return Run{results.Shortest(rs.asResultsRun())}
+}
+
+func (rs RunSlice) Longest() Run {
+	return Run{results.Longest(rs.asResultsRun())}
+}
+
+func (rs RunSlice) Average() time.Duration {
+	return results.Average(results.Durations(rs.asResultsRun()))
+}
+
+func (rs RunSlice) Deviation() time.Duration {
+	return results.Deviation(results.Durations(rs.asResultsRun()))
+}
+
+func (rs RunSlice) NotPassed() []Run {
+	return rs.filter(func(s string) bool { return s != "pass" })
+}
+
+func (rs RunSlice) Failed() []Run {
+	return rs.filter(func(s string) bool { return s != "pass" && s != "unstable" })
+}
+
+func (rs RunSlice) Unstable() []Run {
+	return rs.filter(func(s string) bool { return s == "unstable" })
+}
+
+func (rs RunSlice) Result() string {
+	switch {
+	case len(rs) == 0:
+		return "NORUN"
+
+	case len(rs.Failed()) != 0:
+		return "FAILED"
+
+	case len(rs.Unstable()) != 0:
+		return "UNSTABLE"
+
+	case len(rs.Failed()) == 0 && len(rs.Unstable()) == 0:
+		return "PASSED"
+
+	default:
+		return "FAILED"
+	}
+}
+
+func (rs RunSlice) filter(f func(s string) bool) []Run {
+	ret := make([]Run, 0, len(rs))
+	for _, r := range rs {
 		if f(r.Verdict) {
 			ret = append(ret, r)
 		}
@@ -172,23 +223,12 @@ func (c Collection) filter(f func(s string) bool) []Run {
 	return ret
 }
 
-func (c Collection) Result() string {
-	switch {
-	case len(c.Tests) == 0:
-		return "NORUN"
-
-	case len(c.Failed()) != 0:
-		return "FAILED"
-
-	case len(c.Unstable()) != 0:
-		return "UNSTABLE"
-
-	case len(c.Failed()) == 0 && len(c.Unstable()) == 0:
-		return "PASSED"
-
-	default:
-		return "FAILED"
+func (rs RunSlice) asResultsRun() []results.Run {
+	ret := make([]results.Run, len(rs))
+	for i, r := range rs {
+		ret[i] = r.Run
 	}
+	return ret
 }
 
 type Run struct{ results.Run }
@@ -203,4 +243,26 @@ func (r Run) Module() string {
 func (r Run) Testcase() string {
 	f := strings.Split(r.Name, ".")
 	return f[len(f)-1]
+}
+
+func (r Run) ReasonFiles() ([]File, error) {
+	paths, err := filepath.Glob(filepath.Join(r.WorkingDir, "*.reason"))
+	if err != nil {
+		return nil, err
+	}
+
+	var files []File
+	for _, p := range paths {
+		b, err := ioutil.ReadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, File{p, string(b)})
+	}
+	return files, err
+}
+
+type File struct {
+	Name    string
+	Content string
 }

--- a/internal/ntt/ntt.go
+++ b/internal/ntt/ntt.go
@@ -146,6 +146,9 @@ func (suite *Suite) SetRoot(folder string) {
 func (suite *Suite) LatestResults() (*results.DB, error) {
 	b, err := suite.File("test_results.json").Bytes()
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/internal/ntt/ntt.go
+++ b/internal/ntt/ntt.go
@@ -1,6 +1,7 @@
 package ntt
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/nokia/ntt/internal/memoize"
+	"github.com/nokia/ntt/internal/results"
 	"github.com/nokia/ntt/internal/session"
 	"github.com/nokia/ntt/internal/span"
 )
@@ -139,6 +141,16 @@ func (suite *Suite) Root() *File {
 func (suite *Suite) SetRoot(folder string) {
 	suite.root = suite.File(folder)
 	suite.sources = nil
+}
+
+func (suite *Suite) LatestResults() (*results.DB, error) {
+	b, err := suite.File("test_results.json").Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	var db results.DB
+	return &db, json.Unmarshal(b, &db)
 }
 
 func init() {

--- a/internal/results/results.go
+++ b/internal/results/results.go
@@ -43,6 +43,7 @@ func (r *Run) Duration() time.Duration {
 	return r.End.Sub(r.Begin.Time)
 }
 
+// String returns a printable and simplified representation of Run
 func (r *Run) String() string {
 	return fmt.Sprintf("%s	%s	%s", r.Verdict, r.ID(), r.Duration())
 }
@@ -157,7 +158,11 @@ func Durations(runs []Run) []time.Duration {
 	return ret
 }
 
-// FinalVerdicts folds multiple runs instances into one
+// FinalVerdicts folds multiple runs instances into one with a final verdict.
+//
+// * A test is considered "pass", if all runs had verdict "pass".
+// * A test is considered "unstable", if only some runs had verdict "pass"
+// * Runs with worse or equal verdict will overwrite previous runs.
 func FinalVerdicts(runs []Run) []Run {
 
 	severity := func(verdict string) int {

--- a/internal/results/results.go
+++ b/internal/results/results.go
@@ -2,6 +2,7 @@ package results
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -13,7 +14,7 @@ type DB struct {
 	Version int
 	MaxJobs int
 	MaxLoad int
-	runs    []Run
+	Runs    []Run
 }
 
 // A Run describes the execution of a single test case.
@@ -34,17 +35,17 @@ type Run struct {
 }
 
 // A unique identifier of the run. Usually something like "testname-2"
-func (r *Run) ID() string {
+func (r Run) ID() string {
 	return r.Name + "-" + fmt.Sprintf("%d\n", r.Instance)
 }
 
 // Duration of an individual run
-func (r *Run) Duration() time.Duration {
+func (r Run) Duration() time.Duration {
 	return r.End.Sub(r.Begin.Time)
 }
 
 // String returns a printable and simplified representation of Run
-func (r *Run) String() string {
+func (r Run) String() string {
 	return fmt.Sprintf("%s	%s	%s", r.Verdict, r.ID(), r.Duration())
 }
 
@@ -245,6 +246,32 @@ func Average(slice []time.Duration) time.Duration {
 	// even slice length
 	return (slice[n-1] + slice[n]) / 2
 
+}
+
+// Mean returns arithmetic mean
+func Mean(slice []time.Duration) time.Duration {
+	var sum int
+	for _, d := range slice {
+		sum += int(d)
+	}
+
+	return time.Duration(sum / len(slice))
+}
+
+// Deviation returns the standard deviation of duration
+func Deviation(slice []time.Duration) time.Duration {
+	if len(slice) == 0 {
+		return 0
+	}
+
+	mean := Mean(slice)
+
+	v := 0.0
+	for _, d := range slice {
+		v += math.Pow(float64(d), 2) / float64(mean)
+	}
+
+	return time.Duration(math.Sqrt(v))
 }
 
 type durationSlice []time.Duration

--- a/internal/results/results.go
+++ b/internal/results/results.go
@@ -1,0 +1,249 @@
+package results
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// A DB struct contains results of last test executable execution
+type DB struct {
+	Version int
+	MaxJobs int
+	MaxLoad int
+	runs    []Run
+}
+
+// A Run describes the execution of a single test case.
+type Run struct {
+	Name     string // Full qualified test name
+	Instance int    // Test instance
+	Verdict  string // the test verdict (pass, fail, none, ...)
+	Reason   string // Optional reason for verdicts
+
+	Begin Timestamp // When the test was started
+	End   Timestamp // When the test ended
+
+	WorkingDir string  // Working Directory of the test
+	Load       float64 // the system load when the test was started
+	MaxMem     int     // the maximum memory used when the test ended
+
+	RunnerID string `json:"runnerid"`
+}
+
+// A unique identifier of the run. Usually something like "testname-2"
+func (r *Run) ID() string {
+	return r.Name + "-" + fmt.Sprintf("%d\n", r.Instance)
+}
+
+// Duration of an individual run
+func (r *Run) Duration() time.Duration {
+	return r.End.Sub(r.Begin.Time)
+}
+
+func (r *Run) String() string {
+	return fmt.Sprintf("%s	%s	%s", r.Verdict, r.ID(), r.Duration())
+}
+
+// Timestamp is a Unix timestamp in milliseconds.
+type Timestamp struct {
+	time.Time
+}
+
+// MarshalJSON is used to convert the timestamp to JSON
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	ms := t.UnixNano() / int64(time.Millisecond)
+	return []byte(strconv.FormatInt(ms, 10)), nil
+}
+
+// UnmarshalJSON is used to convert the timestamp from JSON
+func (t *Timestamp) UnmarshalJSON(s []byte) (err error) {
+	r := string(s)
+	q, err := strconv.ParseInt(r, 10, 64)
+	if err != nil {
+		return err
+	}
+	secs := q / 1000
+	ms := q % 1000
+	t.Time = time.Unix(secs, ms*int64(time.Millisecond))
+	return nil
+}
+
+// Total returns total time spent if all runs would have been executed sequentially.
+func Total(runs []Run) time.Duration {
+	var sum time.Duration
+	for _, r := range runs {
+		sum += r.Duration()
+	}
+	return sum
+}
+
+// Duration returns the time spent between the first and the last test run.
+func Duration(runs []Run) time.Duration {
+	if len(runs) == 0 {
+		return 0
+	}
+	return Last(runs).End.Sub(First(runs).Begin.Time)
+}
+
+// First returns the first test run
+func First(runs []Run) Run {
+	if len(runs) == 0 {
+		return Run{}
+	}
+
+	first := runs[0]
+	for _, r := range runs {
+		if r.Begin.Before(first.Begin.Time) {
+			first = r
+		}
+	}
+	return first
+}
+
+// Last returns the last test run
+func Last(runs []Run) Run {
+	if len(runs) == 0 {
+		return Run{}
+	}
+
+	last := runs[0]
+	for _, r := range runs {
+		if r.End.After(last.End.Time) {
+			last = r
+		}
+	}
+	return last
+}
+
+// Shortest returns the shortest test run
+func Shortest(runs []Run) Run {
+	if len(runs) == 0 {
+		return Run{}
+	}
+
+	shortest := runs[0]
+	for _, r := range runs {
+		if r.Duration() < shortest.Duration() {
+			shortest = r
+		}
+	}
+	return shortest
+}
+
+// Longest returns the longest test run
+func Longest(runs []Run) Run {
+	if len(runs) == 0 {
+		return Run{}
+	}
+
+	longest := runs[0]
+	for _, r := range runs {
+		if r.Duration() > longest.Duration() {
+			longest = r
+		}
+	}
+	return longest
+}
+
+// Duration returns a slice of test run durations
+func Durations(runs []Run) []time.Duration {
+	ret := make([]time.Duration, len(runs))
+	for i := range runs {
+		ret[i] = runs[i].Duration()
+	}
+	return ret
+}
+
+// FinalVerdicts folds multiple runs instances into one
+func FinalVerdicts(runs []Run) []Run {
+
+	severity := func(verdict string) int {
+		switch strings.TrimSpace(strings.ToLower(verdict)) {
+		case "pass":
+			return 0
+		case "none", "":
+			return 1
+		case "inconc":
+			return 2
+		case "fail":
+			return 3
+		case "error":
+			return 4
+		default:
+			return 5
+		}
+	}
+
+	var (
+		tests    = make(map[string]Run)
+		names    = make([]string, 0, len(runs))
+		passed   = make(map[string]bool)
+		unstable = make(map[string]bool)
+	)
+
+	for _, run := range runs {
+		last, ok := tests[run.Name]
+		if !ok {
+			names = append(names, run.Name)
+			last = run
+		}
+
+		// A test is a success if it passes at least once.
+		if run.Verdict == "pass" {
+			passed[run.Name] = true
+		}
+
+		// A test is unstable if it has its verdicts change
+		if run.Verdict != last.Verdict {
+			unstable[run.Name] = true
+		}
+
+		// Remember worst and latest test run for post analysis
+		if severity(run.Verdict) >= severity(last.Verdict) {
+			tests[run.Name] = run
+		}
+	}
+
+	ret := make([]Run, len(names))
+	for i, name := range names {
+		t := tests[name]
+		if passed[name] {
+			t.Verdict = "pass"
+			if unstable[name] {
+				t.Verdict = "unstable"
+			}
+		}
+
+		ret[i] = t
+	}
+	return ret
+}
+
+// Average returns the average test duration (median)
+func Average(slice []time.Duration) time.Duration {
+	if len(slice) == 0 {
+		return 0
+	}
+
+	sort.Sort(durationSlice(slice))
+
+	n := len(slice) / 2
+
+	// odd slice length
+	if len(slice)&1 == 1 {
+		return slice[n]
+	}
+
+	// even slice length
+	return (slice[n-1] + slice[n]) / 2
+
+}
+
+type durationSlice []time.Duration
+
+func (a durationSlice) Len() int           { return len(a) }
+func (a durationSlice) Less(i, j int) bool { return a[i] < a[j] }
+func (a durationSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/internal/results/results_test.go
+++ b/internal/results/results_test.go
@@ -1,0 +1,80 @@
+package results
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func run(verdict, id string) Run {
+	fields := strings.Split(id, "-")
+	if len(fields) != 2 {
+		panic("id must be of format $name-$id")
+	}
+	name := fields[0]
+	inst, err := strconv.Atoi(fields[1])
+	if err != nil {
+		panic(err)
+	}
+	return Run{
+		Verdict:  verdict,
+		Name:     name,
+		Instance: inst,
+	}
+}
+
+func stringSlice(runs []Run) []string {
+	ret := make([]string, len(runs))
+	for i := range runs {
+		ret[i] = runs[i].String()
+	}
+	return ret
+}
+
+func TestFinalVerdict(t *testing.T) {
+	actual := stringSlice(FinalVerdicts([]Run{
+		run("fail", "Test.A-0"),
+		run("pass", "Test.A-1"),
+		run("pass", "Test.B-1"),
+		run("fail", "Test.B-0"),
+		run("pass", "Test.C-0"),
+		run("fail", "Test.C-1"),
+		run("fail", "Test.D-1"),
+		run("pass", "Test.D-0"),
+		run("pass", "Test.E-0"),
+		run("pass", "Test.E-1"),
+		run("pass", "Test.F-1"),
+		run("pass", "Test.F-0"),
+		run("fail", "Test.G-0"),
+		run("fail", "Test.G-1"),
+		run("fail", "Test.H-1"),
+		run("fail", "Test.H-0"),
+		run("none", "Test.I-0"),
+		run("inconc", "Test.I-1"),
+		run("inconc", "Test.J-1"),
+		run("none", "Test.J-0"),
+		run("inconc", "Test.K-0"),
+		run("none", "Test.K-1"),
+		run("none", "Test.L-1"),
+		run("inconc", "Test.L-0"),
+	}))
+
+	expected := stringSlice([]Run{
+		run("unstable", "Test.A-0"),
+		run("unstable", "Test.B-0"),
+		run("unstable", "Test.C-1"),
+		run("unstable", "Test.D-1"),
+		run("pass", "Test.E-1"),
+		run("pass", "Test.F-0"),
+		run("fail", "Test.G-1"),
+		run("fail", "Test.H-0"),
+		run("inconc", "Test.I-1"),
+		run("inconc", "Test.J-1"),
+		run("inconc", "Test.K-0"),
+		run("inconc", "Test.L-0"),
+	})
+
+	assert.Equal(t, expected, actual)
+}

--- a/vendor/gopkg.in/check.v1/checkers.go
+++ b/vendor/gopkg.in/check.v1/checkers.go
@@ -161,6 +161,10 @@ func (checker *notNilChecker) Check(params []interface{}, names []string) (resul
 // Equals checker.
 
 func diffworthy(a interface{}) bool {
+	if a == nil {
+		return false
+	}
+
 	t := reflect.TypeOf(a)
 	switch t.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct, reflect.String, reflect.Ptr:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,7 +50,7 @@ google.golang.org/protobuf/reflect/protoreflect
 google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface
 google.golang.org/protobuf/runtime/protoimpl
-# gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+# gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 gopkg.in/check.v1
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2


### PR DESCRIPTION
This PR introduces a new command `report`.

`ntt report` makes use of k3s' verdic file `test_results.json` and provides various kinds of reports:

* Fancy coloured output, useful as summary (`ntt report`)
* ~~tab separated output, useful for piping into 3rd party shells scripts (`ntt report --tsv`)~~
* JUnit report for Jenkins integration (`ntt report --junit`)
* Detailed JSON output, useful for monitoring and statistics. (`ntt report --json`)
* Custom output using Go template engine. (`ntt report --template`)
