### PR TITLE
Add helper command locate-file

### DIFF
--- a/cmd/ntt/main.go
+++ b/cmd/ntt/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nokia/ntt/internal/cmds/langserver"
 	"github.com/nokia/ntt/internal/cmds/lint"
 	"github.com/nokia/ntt/internal/cmds/list"
+	"github.com/nokia/ntt/internal/cmds/locate_file"
 	"github.com/nokia/ntt/internal/cmds/report"
 	"github.com/nokia/ntt/internal/cmds/tags"
 )
@@ -88,6 +89,7 @@ func init() {
 	showCmd.PersistentFlags().BoolVarP(&ShSetup, "sh", "", false, "output test suite data for shell consumption")
 	showCmd.PersistentFlags().BoolVarP(&JSON, "json", "", false, "output in JSON format")
 	rootCmd.AddCommand(dump.Command)
+	rootCmd.AddCommand(locate_file.Command)
 	rootCmd.AddCommand(langserver.Command)
 	rootCmd.AddCommand(lint.Command)
 	rootCmd.AddCommand(list.Command)

--- a/cmd/ntt/show.go
+++ b/cmd/ntt/show.go
@@ -152,22 +152,6 @@ func printJSON(report *Report, keys []string) error {
 func printShellScript(report *Report, keys []string) error {
 	const shellTemplate = `# This is a generated output of ntt show. Args: {{ .Args }}
 
-# k3-cached-file searches for file $1 in $K3_CACHE and $NTT_CACHE and returns its first
-# occurrence.
-function k3-cached-file()
-{
-    local IFS=:
-    read -r -a dirs <<<"$K3_CACHE:$NTT_CACHE"
-    for dir in "${dirs[@]}"; do
-        local cached_file="$dir/$1"
-        if [ -e "$cached_file" ]; then
-            echo "$cached_file"
-            return
-        fi
-    done
-    echo "$1"
-}
-
 # k3-hook calls the K3 test hook (if defined) with action passed by $1.
 function k3-hook()
 {

--- a/internal/cmds/locate_file/\
+++ b/internal/cmds/locate_file/\
@@ -1,0 +1,28 @@
+package locate_file
+
+import (
+	"github.com/nokia/ntt/internal/ntt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	Command = &cobra.Command{
+		Use:    "find-file",
+		Short:  "locate a file using NTT_CACHE",
+		Hidden: true,
+		RunE:   locate,
+	}
+)
+
+func locate(cmd *cobra.Command, args []string) error {
+	suite, err := ntt.NewFromArgs(args...)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range args {
+		srcs, err := suite.File()
+	}
+
+	return nil
+}

--- a/internal/cmds/locate_file/main.go
+++ b/internal/cmds/locate_file/main.go
@@ -1,0 +1,44 @@
+package locate_file
+
+import (
+	"fmt"
+
+	"github.com/nokia/ntt/internal/ntt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	Command = &cobra.Command{
+		Use:    "locate-file",
+		Short:  "locate a file using NTT_CACHE",
+		Hidden: true,
+		RunE:   locate,
+	}
+)
+
+func locate(cmd *cobra.Command, args []string) error {
+	sources, files := splitArgs(args, cmd.ArgsLenAtDash())
+	suite, err := ntt.NewFromArgs(sources...)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range files {
+		if f := suite.File(path); f != nil {
+			fmt.Println(f.Path())
+		}
+	}
+
+	return nil
+}
+
+// splitArgs splits an argument list at pos. Pos is usually the position of '--'
+// (see cobra.Command.ArgsLenAtDash).
+//
+// Is pos < 0, the second list will be empty
+func splitArgs(args []string, pos int) ([]string, []string) {
+	if pos < 0 {
+		return args, []string{}
+	}
+	return args[:pos], args[pos:]
+}

--- a/internal/ntt/ntt.go
+++ b/internal/ntt/ntt.go
@@ -71,8 +71,10 @@ func (suite *Suite) File(path string) *File {
 	if strings.HasPrefix(path, "file://") {
 		uri = span.URIFromURI(path)
 	} else {
-		if s := suite.searchCacheForFile(path); s != "" {
-			path = s
+		if ok, _ := fileExists(path); !ok {
+			if s := suite.searchCacheForFile(path); s != "" {
+				path = s
+			}
 		}
 		uri = span.URIFromPath(path)
 	}
@@ -110,6 +112,11 @@ func (suite *Suite) File(path string) *File {
 // Purpose and behaviour of this function are similar to GNU Make's VPATH. It
 // is used to prevent re-built of generated files.
 func (suite *Suite) searchCacheForFile(file string) string {
+
+	if _, err := os.Stat(file); err == nil {
+		return file
+	}
+
 	if file == "." || file == ".." {
 		return ""
 	}

--- a/internal/ntt/ntt.go
+++ b/internal/ntt/ntt.go
@@ -113,10 +113,6 @@ func (suite *Suite) File(path string) *File {
 // is used to prevent re-built of generated files.
 func (suite *Suite) searchCacheForFile(file string) string {
 
-	if _, err := os.Stat(file); err == nil {
-		return file
-	}
-
 	if file == "." || file == ".." {
 		return ""
 	}


### PR DESCRIPTION
ntt provides a mechanism for locating source files similar to the VPATH
mechanism of GNU Make.

This commit introduces a new command locate-file to help 3rd party tools
using this feature without needing to know the exact policy.

This commit also changes the search behavior of ntt: It first looks at the
current working directory and then consults NTT_CACHE environment
variable for further lookups.