### PR TITLE
No autocompletion for new, unsaved files

### DIFF
--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -393,7 +393,12 @@ func LastNonWsToken(n ast.Node, pos loc.Pos) []ast.Node {
 }
 
 func (s *Server) completion(ctx context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error) {
+	if !params.TextDocument.URI.SpanURI().IsFile() {
+		log.Printf(fmt.Sprintf("for 'code completion' the new file %q needs to be saved at least once", string(params.TextDocument.URI)))
+		return &protocol.CompletionList{}, nil
+	}
 	start := time.Now()
+
 	fileName := filepath.Base(params.TextDocument.URI.SpanURI().Filename())
 	defaultModuleId := fileName[:len(fileName)-len(filepath.Ext(fileName))]
 


### PR DESCRIPTION
vscode has a special URI format for new, unsaved files, which is not compatible with the span package. The URI format changes to __file://__ as soon as the file is saved to the file system