### PR TITLE
Various fixes

### DIFF
--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -60,7 +60,7 @@ func (f *File) ID() string {
 // SetBytes, Bytes will try reading the file path's content from disk.
 func (f *File) Bytes() ([]byte, error) {
 	if f.bytes == nil && f.err == nil {
-		f.bytes, f.err = ioutil.ReadFile(f.path)
+		f.bytes, f.err = ioutil.ReadFile(f.Path())
 		f.version = 0
 	}
 

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -1,0 +1,28 @@
+package fs_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/nokia/ntt/internal/fs"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBytesFromURL verifies, that files specified by an URL can be read.
+func TestBytesFromURL(t *testing.T) {
+	path, err := filepath.Abs("fs_test.go")
+	if err != nil {
+		panic(err)
+	}
+
+	expected, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	f := fs.Open("file://" + path)
+	b, err := f.Bytes()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, b)
+}

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -45,6 +45,12 @@ func cTags(suite *ntt.Suite, file string, line int, col int) []protocol.Location
 	}
 
 	log.Debug(fmt.Sprintf("Parse: %+v", tree))
+
+	// If Module is nil, there's no need to continue, because there's no
+	// AST to iterate over.
+	if tree.Module == nil {
+		return nil
+	}
 	id := suite.IdentifierAt(tree, line, col)
 	if id == nil {
 		return nil

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -40,9 +40,11 @@ func cTags(suite *ntt.Suite, file string, line int, col int) []protocol.Location
 
 	tree := suite.Parse(file)
 	if tree == nil {
+		log.Debug(fmt.Sprintf("Parsing %q failed.", file))
 		return nil
 	}
 
+	log.Debug(fmt.Sprintf("Parse: %+v", tree))
 	id := suite.IdentifierAt(tree, line, col)
 	if id == nil {
 		return nil


### PR DESCRIPTION
This PR solves two issues:
* Files could not be read, when their paths were specified as URL
* Language Server panicked, when Goto-Definition could not read .ttcn3 file.

This PR further adds some logging and a small test to prevent future regression.