### PR TITLE
Move some manifest code to project package

### DIFF
--- a/internal/cmds/list/main.go
+++ b/internal/cmds/list/main.go
@@ -188,7 +188,7 @@ func newBasket(name string, args []string) (basket, error) {
 func loadBaskets(suite *ntt.Suite) error {
 	env, err := suite.Getenv("NTT_LIST_BASKETS")
 	if err != nil || env == "" {
-		if _, ok := err.(*ntt.NoSuchVariableError); ok {
+		if _, ok := err.(*project.NoSuchVariableError); ok {
 			return nil
 		}
 		return err
@@ -202,7 +202,7 @@ func loadBaskets(suite *ntt.Suite) error {
 		flags, err := suite.Getenv("NTT_LIST_BASKETS_" + name)
 		args := strings.Fields(flags)
 		if err != nil {
-			if _, ok := err.(*ntt.NoSuchVariableError); !ok {
+			if _, ok := err.(*project.NoSuchVariableError); !ok {
 				return err
 			}
 			args = []string{"-R", "@" + name}

--- a/internal/ntt/env.go
+++ b/internal/ntt/env.go
@@ -1,118 +1,15 @@
 package ntt
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/hashicorp/go-multierror"
-	"github.com/nokia/ntt/internal/env"
-)
-
-type NoSuchVariableError struct {
-	Name string
-}
-
-func (e *NoSuchVariableError) Error() string {
-	return e.Name + ": variable not defined"
-}
-
-var knownVars = map[string]bool{
-	"CXXFLAGS":            true,
-	"K3CFLAGS":            true,
-	"K3RFLAGS":            true,
-	"LDFLAGS":             true,
-	"LD_LIBRARY_PATH":     true,
-	"PATH":                true,
-	"NTT_DATADIR":         true,
-	"NTT_IMPORTS":         true,
-	"NTT_NAME":            true,
-	"NTT_PARAMETERS_DIR":  true,
-	"NTT_PARAMETERS_FILE": true,
-	"NTT_SOURCES":         true,
-	"NTT_SOURCE_DIR":      true,
-	"NTT_TEST_HOOK":       true,
-	"NTT_TIMEOUT":         true,
-	"NTT_VARIABLES":       true,
-}
-
 // Environ returns a copy of strings representing the environment, in the form "key=value".
 func (suite *Suite) Environ() ([]string, error) {
-	var errs error
-
-	allKeys := make(map[string]struct{})
-
-	vars, err := suite.Variables()
-	if err != nil {
-		errs = multierror.Append(errs, err)
-	}
-	for k := range vars {
-		allKeys[k] = struct{}{}
-	}
-
-	for k := range env.Parse() {
-		allKeys[k] = struct{}{}
-	}
-
-	ret := make([]string, 0, len(allKeys))
-	for k := range allKeys {
-		v, err := suite.Getenv(k)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-		}
-		ret = append(ret, fmt.Sprintf("%s=%s", k, v))
-	}
-	return ret, nil
+	return suite.p.Environ()
 }
 
 // Expand expands string v using Suite.Getenv
 func (suite *Suite) Expand(v string) (string, error) {
-	return suite.expand(v, make(map[string]string))
+	return suite.p.Expand(v)
 }
 
 func (suite *Suite) Getenv(v string) (string, error) {
-	return suite.getenv(v, make(map[string]string))
-}
-
-func (suite *Suite) expand(v string, visited map[string]string) (string, error) {
-	var errs error
-	mapper := func(name string) string {
-		v, err := suite.getenv(name, visited)
-		if err != nil {
-			errs = multierror.Append(errs, &NoSuchVariableError{Name: name})
-		}
-		return v
-	}
-	return os.Expand(v, mapper), errs
-}
-
-func (suite *Suite) getenv(key string, visited map[string]string) (string, error) {
-	if v, ok := visited[key]; ok {
-		return v, nil
-	}
-	visited[key] = ""
-
-	if v, ok := env.LookupEnv(key); ok {
-		visited[key] = v
-		return v, nil
-	}
-	vars, err := suite.Variables()
-	if err != nil {
-		return "", err
-	}
-
-	// We must not look for NTT_CACHE in variables sections of package.yml,
-	// because this would create an endless loop.
-	if key != "NTT_CACHE" && key != "K3_CACHE" {
-		if v, ok := vars[key]; ok {
-			v, err := suite.expand(v, visited)
-			visited[key] = v
-			return v, err
-		}
-	}
-
-	if knownVars[key] {
-		return "", nil
-	}
-
-	return "", &NoSuchVariableError{Name: key}
+	return suite.p.Getenv(v)
 }

--- a/internal/ntt/ntt.go
+++ b/internal/ntt/ntt.go
@@ -32,6 +32,12 @@ type Suite struct {
 	store memoize.Store
 }
 
+func (suite *Suite) lazyInit() {
+	if suite.p == nil {
+		suite.p = &project.Project{}
+	}
+}
+
 // Id returns the unique session id (aka NTT_SESSION_ID). This ID is the smallest
 // integer available on this machine.
 func (suite *Suite) Id() (int, error) {
@@ -54,7 +60,10 @@ func (suite *Suite) Id() (int, error) {
 }
 
 func (suite *Suite) Root() string {
-	return suite.p.Root()
+	if suite.p != nil {
+		return suite.p.Root()
+	}
+	return ""
 }
 
 // SetRoot set the root folder for Suite.

--- a/project/project.go
+++ b/project/project.go
@@ -98,16 +98,21 @@ func Fingerprint(p Interface) string {
 func Open(path string) (*Project, error) {
 	p := Project{root: path}
 
-	if file := filepath.Join(p.root, manifest.Name); fs.IsRegular(file) {
+	// Try reading the manifest
+	file := filepath.Join(p.root, manifest.Name)
+	if b, err := fs.Content(file); err == nil {
 		log.Debugf("%s: update configuration using manifest %q\n", p.String(), file)
-		return &p, p.readManifest(file)
+		return &p, yaml.UnmarshalStrict(b, &p.Manifest)
 	}
 
+	// Fall back to recursive scanning
 	log.Debugf("%s: update configuration using available folders\n", p.String())
-	return &p, p.readFilesystem()
+	return &p, p.findFilesRecursive()
 }
 
-// A Project implements the behaviour expected from ntt ttcn3 suites.
+// A Project provides meta information about a TTCN-3 test suite. Meta
+// information like: Location of configuration and source files, dependency
+// list, default values, ...
 type Project struct {
 	root string
 
@@ -138,7 +143,10 @@ func (p *Project) Sources() ([]string, error) {
 
 	var srcs []string
 	for _, src := range p.Manifest.Sources {
-		src := fs.Real(p.Root(), p.expand(src))
+		src, err := p.evalPath(src)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
 
 		info, err := os.Stat(src)
 		switch {
@@ -174,7 +182,10 @@ func (p *Project) Imports() ([]string, error) {
 
 	var imports []string
 	for _, dir := range p.Manifest.Imports {
-		dir := fs.Real(p.Root(), p.expand(dir))
+		dir, err := p.evalPath(dir)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
 		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 			errs = multierror.Append(errs, fmt.Errorf("%q must be a directory", dir))
 		}
@@ -209,29 +220,7 @@ func (p *Project) FindModule(name string) (string, error) {
 	return "", fmt.Errorf("No such module %q", name)
 }
 
-func (p *Project) expand(s string) string {
-	mapper := func(name string) string {
-		if s, ok := env.LookupEnv(name); ok {
-			return s
-		}
-		if s, ok := p.Manifest.Variables[name]; ok {
-			return s
-		}
-		return fmt.Sprintf("${UNKNOWN:%s}", name)
-	}
-
-	return os.Expand(s, mapper)
-}
-
-func (p *Project) readManifest(file string) error {
-	b, err := fs.Open(file).Bytes()
-	if err != nil {
-		return err
-	}
-	return yaml.UnmarshalStrict(b, &p.Manifest)
-}
-
-func (p *Project) readFilesystem() error {
+func (p *Project) findFilesRecursive() error {
 	addSources := func(path string, info os.FileInfo, err error) error {
 		if err == nil && info.IsDir() {
 			files, _ := filepath.Glob(filepath.Join(path, "*.ttcn*"))
@@ -265,4 +254,112 @@ func (p *Project) readFilesystem() error {
 		}
 	}
 	return nil
+}
+
+// Environ returns a copy of strings representing the environment, in the form "key=value".
+func (p *Project) Environ() ([]string, error) {
+	var errs error
+
+	allKeys := make(map[string]struct{})
+
+	for k := range p.Manifest.Variables {
+		allKeys[k] = struct{}{}
+	}
+
+	for k := range env.Parse() {
+		allKeys[k] = struct{}{}
+	}
+
+	ret := make([]string, 0, len(allKeys))
+	for k := range allKeys {
+		v, err := p.Getenv(k)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		ret = append(ret, fmt.Sprintf("%s=%s", k, v))
+	}
+	return ret, nil
+}
+
+// Expand expands string v using Project.Getenv
+func (p *Project) Expand(v string) (string, error) {
+	return p.expand(v, make(map[string]string))
+}
+
+func (p *Project) Getenv(v string) (string, error) {
+	return p.getenv(v, make(map[string]string))
+}
+
+func (p *Project) expand(v string, visited map[string]string) (string, error) {
+	var errs error
+	mapper := func(name string) string {
+		v, err := p.getenv(name, visited)
+		if err != nil {
+			errs = multierror.Append(errs, &NoSuchVariableError{Name: name})
+		}
+		return v
+	}
+	return os.Expand(v, mapper), errs
+}
+
+func (p *Project) getenv(key string, visited map[string]string) (string, error) {
+	if v, ok := visited[key]; ok {
+		return v, nil
+	}
+	visited[key] = ""
+
+	if v, ok := env.LookupEnv(key); ok {
+		visited[key] = v
+		return v, nil
+	}
+	// We must not look for NTT_CACHE in variables sections of package.yml,
+	// because this would create an endless loop.
+	if key != "NTT_CACHE" && key != "K3_CACHE" {
+		if v, ok := p.Manifest.Variables[key]; ok {
+			v, err := p.expand(v, visited)
+			visited[key] = v
+			return v, err
+		}
+	}
+
+	if knownVars[key] {
+		return "", nil
+	}
+
+	return "", &NoSuchVariableError{Name: key}
+}
+
+func (p *Project) evalPath(path string) (string, error) {
+	subst, err := p.Expand(path)
+	if err == nil {
+		path = subst
+	}
+	return fs.Real(p.Root(), path), err
+}
+
+type NoSuchVariableError struct {
+	Name string
+}
+
+func (e *NoSuchVariableError) Error() string {
+	return e.Name + ": variable not defined"
+}
+
+var knownVars = map[string]bool{
+	"CXXFLAGS":            true,
+	"K3CFLAGS":            true,
+	"K3RFLAGS":            true,
+	"LDFLAGS":             true,
+	"LD_LIBRARY_PATH":     true,
+	"PATH":                true,
+	"NTT_DATADIR":         true,
+	"NTT_IMPORTS":         true,
+	"NTT_NAME":            true,
+	"NTT_PARAMETERS_DIR":  true,
+	"NTT_PARAMETERS_FILE": true,
+	"NTT_SOURCES":         true,
+	"NTT_SOURCE_DIR":      true,
+	"NTT_TEST_HOOK":       true,
+	"NTT_TIMEOUT":         true,
+	"NTT_VARIABLES":       true,
 }


### PR DESCRIPTION
This commit moves manifest file and variables handling from internal/ntt to project package.

The idea behind is to create a more data centric API for manifests. Before we can use value objects and such, we have to decouple things first.
