### PR TITLE
Add new environment implementation

### DIFF
--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -2,9 +2,12 @@ package env_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/nokia/ntt/internal/env"
+	"github.com/nokia/ntt/internal/fs"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -28,4 +31,171 @@ func TestCache(t *testing.T) {
 		t.Errorf("Want: NTT_FOO=%q, Got: NTT_FOO=%q", "bar", env)
 	}
 
+}
+
+func TestEnvEmpty(t *testing.T) {
+	clearEnv()
+	assert.Equal(t, "", env.Getenv("NTT_FNORD"))
+}
+
+func TestEnvSimple(t *testing.T) {
+	clearEnv()
+	os.Setenv("NTT_FNORD", "23.5")
+	assert.Equal(t, "23.5", env.Getenv("NTT_FNORD"))
+}
+
+func TestEnvK3(t *testing.T) {
+	clearEnv()
+	os.Setenv("K3FNORD", "23.5")
+	assert.Equal(t, "23.5", env.Getenv("NTTFNORD"))
+}
+
+// Test that NTT prefix is replaced with K3 prefix.
+//
+// When, for example, asking for NTT_CACHE, we should also look for any
+// K3_CACHE variables of legacy systems.
+func TestPrefixReplaceNTT(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `K3_FNORD="var2"`)
+	env.Load("ntt.env")
+	assert.Equal(t, "var2", env.Getenv("NTT_FNORD"))
+	assert.Equal(t, "var2", env.Getenv("K3_FNORD"))
+}
+
+// Verify that K3 prefix is _not_ replaced with NTT prefix.
+func TestPrefixKeepK3(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `NTT_FNORD="var1"`)
+	env.Load("ntt.env")
+	assert.Equal(t, "var1", env.Getenv("NTT_FNORD"))
+	assert.Equal(t, "", env.Getenv("K3_FNORD"))
+}
+
+// Verify that prefix substituion does not overwrite existing variables
+func TestPrefixHasBoth(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `NTT_FNORD="var1"
+	K3_FNORD="var2"`)
+	env.Load()
+	assert.Equal(t, "var1", env.Getenv("NTT_FNORD"))
+	assert.Equal(t, "var2", env.Getenv("K3_FNORD"))
+}
+
+// Verify that ntt.env is loaded before k3.env
+func TestEnvK3BeforeNTT(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `NTT_FNORD="fromNTT"`)
+	setContent("k3.env", `NTT_FNORD="fromK3"
+	K3_FNORD="fromK3"`)
+	env.Load()
+	assert.Equal(t, "fromNTT", env.Getenv("NTT_FNORD"))
+	assert.Equal(t, "fromK3", env.Getenv("K3_FNORD"))
+}
+
+// Verify that ntt.env is loaded before k3.env, like before, but with difference prefixes
+func TestEnvK3BeforeNTTWithSubstitution(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `K3_FNORD="fromNTT"`)
+	setContent("k3.env", `NTT_FNORD="fromK3"
+	K3_FNORD="fromK3"`)
+	env.Load()
+	assert.Equal(t, "fromK3", env.Getenv("NTT_FNORD"))
+	assert.Equal(t, "fromNTT", env.Getenv("K3_FNORD"))
+}
+
+// Test if os environment overwrites environment files.
+//
+// This behaviour has been removed, because variables from environment files
+// have been promoted to real os environment variables
+//
+//func TestPrecedence(t *testing.T) {
+//	clearEnv()
+//	setContent("ntt.env", `NTT_FNORD="fromNTT"`)
+//	env.Load()
+//	os.Setenv("K3_FNORD", "fromEnv")
+//	assert.Equal(t, "fromEnv", env.Getenv("NTT_FNORD"))
+//}
+
+// Test if types are converted to strings nicely.
+func TestEnvConversion(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `NTT_FLOAT=23.5`)
+	env.Load()
+	assert.Equal(t, "23.5", env.Getenv("NTT_FLOAT"))
+}
+
+// Ensure that variables are substituted
+func TestEnvExpansion(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `
+		NTT_A=a
+		NTT_B=$NTT_A
+	`)
+	env.Load()
+	assert.Equal(t, "a", env.Getenv("NTT_B"))
+}
+
+func TestEnvExpansion2(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `
+		NTT_C=23.5
+		NTT_B=${NTT_C} $NTT_C
+	`)
+	env.Load()
+	assert.Equal(t, "23.5 23.5", env.Getenv("NTT_B"))
+}
+
+// Environment files are evaluted line by line. Line order matters.
+func TestEnvExpansionEnv(t *testing.T) {
+	clearEnv()
+	os.Setenv("NTT_A", "fromEnv")
+	setContent("ntt.env", `
+		NTT_B=$NTT_A
+		NTT_A=a
+	`)
+	env.Load()
+	assert.Equal(t, "fromEnv", env.Getenv("NTT_B"))
+}
+
+// Unknown variables are substituted with empty string.
+func TestEnvExpansionUnknown(t *testing.T) {
+	clearEnv()
+	setContent("ntt.env", `
+		NTT_B=$NTT_A
+		NTT_A=a
+	`)
+	env.Load()
+	assert.Equal(t, "", env.Getenv("NTT_B"))
+}
+
+func setContent(file string, content string) {
+	fs.Open(file).SetBytes([]byte(content))
+}
+
+func clearEnv(files ...string) {
+	if len(files) == 0 {
+		files = []string{"ntt.env", "k3.env"}
+	}
+	for _, file := range files {
+		fs.Open(file).SetBytes(nil)
+	}
+
+	for _, e := range os.Environ() {
+		if fields := strings.Split(e, "="); len(fields) == 0 {
+			key := fields[0]
+			if strings.HasPrefix(key, "K3") || strings.HasPrefix(key, "NTT") {
+				os.Unsetenv(key)
+			}
+		}
+	}
+
+	os.Unsetenv("K3_FNORD")
+	os.Unsetenv("NTT_FNORD")
+	os.Unsetenv("NTT_FLOAT")
+	os.Unsetenv("NTT_A")
+	os.Unsetenv("NTT_B")
+	os.Unsetenv("NTT_C")
+	os.Unsetenv("NTT_D")
+	os.Unsetenv("NTT_E")
+	os.Unsetenv("NTT_F")
 }

--- a/internal/ntt/cli.go
+++ b/internal/ntt/cli.go
@@ -110,7 +110,6 @@ func NewFromFiles(files ...string) (*Suite, error) {
 	}
 
 	suite := &Suite{}
-	suite.AddEnvFiles("ntt.env", "k3.env")
 	suite.AddSources(files...)
 	return suite, nil
 }
@@ -133,7 +132,6 @@ func NewFromDirectory(dir string) (*Suite, error) {
 	}
 
 	suite := &Suite{}
-	suite.AddEnvFiles("ntt.env", "k3.env")
 	suite.SetRoot(dir)
 	return suite, nil
 }

--- a/internal/ntt/ntt.go
+++ b/internal/ntt/ntt.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/nokia/ntt/internal/env"
 	"github.com/nokia/ntt/internal/fs"
 	"github.com/nokia/ntt/internal/log"
 	"github.com/nokia/ntt/internal/memoize"
@@ -40,7 +41,7 @@ type Suite struct {
 // integer available on this machine.
 func (suite *Suite) Id() (int, error) {
 	if suite.id == 0 {
-		if s, _ := suite.lookupProcessEnv("NTT_SESSION_ID)"); s != "" {
+		if s, ok := env.LookupEnv("NTT_SESSION_ID)"); ok {
 			id, err := strconv.ParseUint(s, 10, 32)
 			if err != nil {
 				return 0, err
@@ -85,6 +86,8 @@ func (suite *Suite) LatestResults() (*results.DB, error) {
 }
 
 func init() {
+	env.Load()
+
 	// TODO(5nord) We still have to figure how this sharedDir could be handled
 	// more elegantly, maybe even with support for Windows.
 	//


### PR DESCRIPTION
This commit replaces our custom environment handling implementation with
a port of the better known dotenv project.
It also introduces some breaking changes:

* ntt.env is evaluated before k3.env
* NTT_ prefix has a higher precedence than K3_ prefix
* all variables have to be defined up-front
* all unknown environment variables will be replaced with ""