### PR TITLE
Use ttcn3.ParseFile

### DIFF
--- a/internal/cmds/dump/main.go
+++ b/internal/cmds/dump/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nokia/ntt/internal/ttcn3/ast"
 	"github.com/nokia/ntt/internal/ttcn3/printer"
 	"github.com/nokia/ntt/project"
+	"github.com/nokia/ntt/ttcn3"
 	"github.com/spf13/cobra"
 )
 
@@ -28,11 +29,11 @@ var (
 
 			files, _ := project.Files(suite)
 			for _, file := range files {
-				info := suite.Parse(file)
-				if ttcn3 {
-					printer.Print(os.Stdout, info.FileSet, info.Module)
+				tree := ttcn3.ParseFile(file)
+				if useTTCN3 {
+					printer.Print(os.Stdout, tree.FileSet, tree.Root)
 				} else {
-					dump(reflect.ValueOf(info.Module), "Root: ")
+					dump(reflect.ValueOf(tree.Root), "Root: ")
 				}
 			}
 
@@ -40,11 +41,11 @@ var (
 		},
 	}
 
-	ttcn3 = false
+	useTTCN3 = false
 )
 
 func init() {
-	Command.PersistentFlags().BoolVarP(&ttcn3, "ttcn3", "", false, "formatted TTCN-3 output")
+	Command.PersistentFlags().BoolVarP(&useTTCN3, "ttcn3", "", false, "formatted TTCN-3 output")
 }
 
 func dump(v reflect.Value, f string) {

--- a/internal/cmds/run/main.go
+++ b/internal/cmds/run/main.go
@@ -72,8 +72,8 @@ func check(files ...*ttcn3.Tree) error {
 		},
 	}
 	for _, file := range files {
-		info.Fset = file.Fset
-		info.CollectInfo(file.Modules())
+		info.Fset = file.FileSet
+		info.CollectInfo(file.Root)
 	}
 	return errs.ErrorOrNil()
 }
@@ -82,7 +82,7 @@ func check(files ...*ttcn3.Tree) error {
 func load(env *runtime.Env, files ...*ttcn3.Tree) error {
 	var err error
 	for _, file := range files {
-		result := interpreter.Eval(file.Modules(), env)
+		result := interpreter.Eval(file.Root, env)
 		if rerr, ok := result.(*runtime.Error); ok {
 			err = multierror.Append(err, rerr)
 		}

--- a/ttcn3/ttcn3.go
+++ b/ttcn3/ttcn3.go
@@ -24,18 +24,9 @@ var (
 
 // Tree represents the TTCN-3 syntax tree, usually of a file.
 type Tree struct {
-	Fset *loc.FileSet
-	mods []*ast.Module
-	Err  error
-}
-
-// Modules returns the list of modules in the syntax tree.
-func (t *Tree) Modules() ast.NodeList {
-	nodes := make(ast.NodeList, len(t.mods))
-	for i, m := range t.mods {
-		nodes[i] = m
-	}
-	return nodes
+	FileSet *loc.FileSet
+	Root    ast.NodeList
+	Err     error
 }
 
 // ParseFile parses a file and returns a syntax tree.
@@ -51,8 +42,8 @@ func ParseFile(path string) *Tree {
 		defer func() { <-parseLimit }()
 
 		fset := loc.NewFileSet()
-		mods, err := parser.ParseModules(fset, path, b, parser.AllErrors)
-		return &Tree{Fset: fset, mods: mods, Err: err}
+		root, err := parser.Parse(fset, path, b)
+		return &Tree{FileSet: fset, Root: root, Err: err}
 	})
 
 	return f.Handle.Get(context.TODO()).(*Tree)


### PR DESCRIPTION
This commit replaces parser calls `parser.ParseModule`,
`suite.Parse` with `ttcn3.ParseFile`.

Exceptions are the internals/lsp and internal/ntt packages. Because
internal/lsp parser calls depend on typesystem being finished. and
internal/ntt parser calls depend on internal/lsp being replaced first.

Why this change? We are working towards a more IDE-friendly parser API.
Those changes keep technical debt in check.