### PR TITLE
Refactor ntt.test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nokia/ntt
 go 1.13
 
 require (
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/golang/protobuf v1.4.2
 	github.com/gosimple/slug v1.10.0
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/internal/fs/utils.go
+++ b/internal/fs/utils.go
@@ -95,21 +95,13 @@ func FindCFiles(dir string) []string {
 
 // FindFilesRecursive returns a list files from the whole directory subtree.
 func FindFilesRecursive(dir string) []string {
-	files, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return []string{}
-	}
-
 	var sources []string
-	for _, file := range files {
-		if file.Mode().IsRegular() {
-			fname := file.Name()
-			fname, _ = filepath.Abs(filepath.Join(dir, fname))
-			sources = append(sources, ":"+fname)
-		} else if file.Mode().IsDir() {
-			sources = append(sources, FindFilesRecursive(filepath.Join(dir, file.Name()))...)
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && info.Mode().IsRegular() {
+			sources = append(sources, path)
 		}
-	}
+		return nil
+	})
 	return sources
 }
 
@@ -142,6 +134,18 @@ func IsFsRoot(path string) bool {
 		root = vol + "\\"
 	}
 	return path == root
+}
+
+// Abs makes paths absolute, when not absolute already.
+func Abs(paths ...string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	ret := make([]string, len(paths))
+	for i, path := range paths {
+		ret[i], _ = filepath.Abs(path)
+	}
+	return ret
 }
 
 // Rel makes paths relative to base, when not absolute already. Use it when

--- a/internal/lsp/commands.go
+++ b/internal/lsp/commands.go
@@ -62,13 +62,17 @@ func nttTest(s *Server, fileURI string, testID string) error {
 
 	log.Printf(`
 ===============================================================================
-Running test %s in %q`, testID, suite.Root())
+Compiling test %s in %q`, testID, suite.Root())
 
-	r, err := runner.New(suite)
+	r, err := runner.New(s, suite)
 	if err != nil {
 		s.Log(context.TODO(), err.Error())
 		return err
 	}
+
+	log.Printf(`
+===============================================================================
+Running test %s in %q`, testID, suite.Root())
 
 	err = r.Run(s, testID)
 

--- a/internal/lsp/commands.go
+++ b/internal/lsp/commands.go
@@ -3,17 +3,13 @@ package lsp
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
-	"github.com/nokia/ntt/internal/env"
 	"github.com/nokia/ntt/internal/fs"
 	"github.com/nokia/ntt/internal/loc"
+	"github.com/nokia/ntt/internal/log"
 	"github.com/nokia/ntt/internal/lsp/protocol"
-	"github.com/nokia/ntt/internal/ntt"
-	"github.com/nokia/ntt/project"
+	"github.com/nokia/ntt/runner"
 )
 
 // NewCommand returns a CodeLens command.
@@ -64,154 +60,27 @@ func nttTest(s *Server, fileURI string, testID string) error {
 		return err
 	}
 
-	// Execute ntt build backend (k3-build)
-	build_cmd := nttCommand(suite, "build")
-	if str := env.Getenv("NTT_DEBUG"); str != "" {
-		if str == "all" {
-			build_cmd.Args = append(build_cmd.Args, "-vvvvv")
-		} else {
-			build_cmd.Args = append(build_cmd.Args, "-v")
-		}
-	}
-
-	// Execute ntt run backend (k3s)
-	cmd := nttCommand(suite, "run", "-j1", "--results-file=test_results.json", "--no-summary", "--no-color")
-	if s := env.Getenv("NTT_DEBUG"); s != "" {
-		cmd.Args = append(cmd.Args, "--debug")
-	}
-	cmd.Stdin = strings.NewReader(testID + "\n")
-	s.Log(context.TODO(), fmt.Sprintf(`
+	log.Printf(`
 ===============================================================================
-Executing test  : %q
-compile command : %s
-run command     : %s
-cwd             : %s
-===============================================================================`,
-		testID, build_cmd.String(), cmd.String(), cmd.Dir))
+Running test %s in %q`, testID, suite.Root())
 
-	// compile test
-	s.Log(context.TODO(), "compiling ...\n")
-	out, err := build_cmd.CombinedOutput()
-	s.Log(context.TODO(), string(out))
-
-	if err != nil {
-		s.Log(context.TODO(), err.Error())
-		return err
-	}
-	s.Log(context.TODO(), build_cmd.ProcessState.String())
-
-	// clean logs from all previous runs of actual test
-	removeLogsForTest(s, filepath.Join(cmd.Dir, "logs"), testID)
-	// run test
-	s.Log(context.TODO(), "running ...\n")
-	out, err = cmd.CombinedOutput()
-	s.Log(context.TODO(), string(out))
-	if err != nil {
-		s.Log(context.TODO(), err.Error())
-	} else {
-		s.Log(context.TODO(), cmd.ProcessState.String())
-	}
-
-	// Continue anyway to execute ntt report
-	cmd = nttCommand(suite, "report")
-	out, err = cmd.CombinedOutput()
-	s.Log(context.TODO(), string(out))
+	r, err := runner.New(suite)
 	if err != nil {
 		s.Log(context.TODO(), err.Error())
 		return err
 	}
 
-	// Display nice artifact overview for convenient navigation
-	logDir := filepath.Join(cmd.Dir, "logs", testID+"-0")
-	s.Log(context.TODO(), fmt.Sprintf(`
+	err = r.Run(s, testID)
+
+	// Show a directory listing of the artifacts.
+	logDir := r.LogDir(testID)
+	if files := fs.Abs(fs.FindFilesRecursive(logDir)...); len(files) > 0 {
+		s.Log(context.Background(), fmt.Sprintf(`
 Content of log directory %q:
 ===============================================================================
-%s`,
-		logDir, strings.Join(fs.FindFilesRecursive(logDir), "\n")))
-	return nil
-}
-
-// nttCommand will return a exec.Cmd for executing a ntt sub-command.
-// It will set path to ntt-binary, proper test suite arguments, environ
-// variables and working directory.
-func nttCommand(suite *ntt.Suite, name string, opts ...string) *exec.Cmd {
-	cmd := exec.Command(findExecutable())
-	cmd.Args = append(cmd.Args, name)
-	cmd.Args = append(cmd.Args, suiteArgs(suite)...)
-	cmd.Args = append(cmd.Args, opts...)
-	cmd.Env = os.Environ()
-	for k, v := range map[string]string{
-		"SCT_K3_SERVER": "ON",
-		"NTT_COLORS":    "never",
-		"NTT_CACHE":     strings.Join(cacheDirs(suite), ":"),
-		"K3CFLAGS":      k3cFlags(suite),
-	} {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
-	}
-	cmd.Dir = filepath.Join(fs.Path(suite.Root()), "ntt.test")
-	os.Mkdir(cmd.Dir, 0755)
-	return cmd
-}
-
-// remove log files from previous runs
-func removeLogsForTest(s *Server, baseDir string, tcName string) {
-	files, _ := filepath.Glob(filepath.Join(baseDir, tcName+"-*"))
-	for _, f := range files {
-		if err := os.RemoveAll(f); err != nil {
-			s.Log(context.TODO(), fmt.Sprintf("error removing %q: %s", f, err.Error()))
-		}
-	}
-}
-
-// suiteArgs returns the suite arguments require to execute ntt commands. Which
-// is either the test suite root folder or a list of TTCN-3 files.
-func suiteArgs(suite *ntt.Suite) []string {
-	if root := fs.Path(suite.Root()); root != "" {
-		return []string{root}
-	}
-	return project.FindAllFiles(suite)
-}
-
-// cacheDirs returns directories of interest. Such as parameters dir or build dir.
-func cacheDirs(suite *ntt.Suite) []string {
-	dirs := strings.Split(env.Getenv("NTT_CACHE"), ":")
-
-	// Large test suites usually require some environment setup to function correctly.
-	if path := fs.FindK3EnvInCurrPath(fs.Path(suite.Root())); path != "" {
-		dirs = append(dirs, path)
+%s\n\n`,
+			logDir, strings.Join(files, "\n")))
 	}
 
-	// Test suite might store additional configuration in their parameter files.
-	if path, _ := suite.ParametersDir(); path != "" {
-		dirs = append(dirs, path)
-	}
-	return dirs
-}
-
-// k3cFlags expand k3.env variable K3CFLAGS with a flag to
-// disable color output.
-//
-// VSCode Ouput channel has only poor support for ANSI color sequences.
-// It's best we disable colors all together.
-func k3cFlags(suite *ntt.Suite) string {
-	flags := "--diagnostics-color=never"
-	if ext, _ := suite.Getenv("K3CFLAGS"); ext != "" {
-		flags = ext + " " + flags
-	}
-	return flags
-}
-
-// findExecutable looks for ntt binary in various locations.
-//
-// If no ntt binary is available findExecutable will return the path of the
-// current executable. This situation happens (for example) when users use a
-// automatically installed ntt binary with no prefix root environment loaded.
-func findExecutable() string {
-	if exe, err := exec.LookPath("ntt"); err == nil {
-		return exe
-	}
-	if exe, err := os.Executable(); err == nil {
-		return exe
-	}
-	return "ntt"
+	return err
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"unicode"
 
+	"github.com/acarl005/stripansi"
 	"github.com/nokia/ntt/internal/env"
 	"github.com/nokia/ntt/internal/fs"
 	"github.com/nokia/ntt/internal/log"
@@ -101,7 +102,7 @@ func (s *Server) Info(ctx context.Context, msg string) {
 func (s *Server) Log(ctx context.Context, msg string) {
 	s.client.LogMessage(ctx, &protocol.LogMessageParams{
 		Type:    protocol.Log,
-		Message: msg,
+		Message: stripansi.Strip(msg),
 	})
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -112,6 +112,13 @@ func (s *Server) Output(level log.Level, msg string) error {
 	return nil
 }
 
+func (s *Server) Write(p []byte) (n int, err error) {
+	str := string(p)
+	s.Log(context.Background(), str)
+	return len(str), nil
+
+}
+
 func (s *Server) cancelRequest(ctx context.Context, params *protocol.CancelParams) error {
 	return nil
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1,0 +1,188 @@
+package runner
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/nokia/ntt/internal/env"
+	"github.com/nokia/ntt/internal/fs"
+	"github.com/nokia/ntt/internal/log"
+	"github.com/nokia/ntt/project"
+)
+
+type Runner struct {
+	// Project.Interface provides files and root directory.
+	p project.Interface
+
+	// Working directory
+	Dir string
+}
+
+func (r *Runner) Run(w io.Writer, testID string) error {
+
+	// Clear any previous artifacts.
+	r.clean(testID)
+
+	// Execute test (k3s backend)
+	cmd := nttCommand(r.p, "run", "-j1", "--results-file=test_results.json", "--no-summary")
+	cmd.Env = append(cmd.Env, "SCT_K3_SERVER=ON")
+	cmd.Stdin = strings.NewReader(testID + "\n")
+
+	out, err := cmd.CombinedOutput()
+	w.Write(out)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+	}
+	w.Write([]byte(cmd.ProcessState.String()))
+
+	return r.report(w, testID)
+}
+
+func (r *Runner) report(w io.Writer, testID string) error {
+
+	// Display a nice summary
+	cmd := nttCommand(r.p, "report")
+	out, err := cmd.CombinedOutput()
+	w.Write(out)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+	}
+
+	return err
+}
+
+// clean removes all artifacts of testID from the working directory.
+func (r *Runner) clean(testID string) {
+	files, _ := filepath.Glob(filepath.Join(r.Dir, "logs", testID+"-*"))
+	for _, f := range files {
+		if err := os.RemoveAll(f); err != nil {
+			log.Debugf("Removing %q failed: %s", f, err)
+		}
+	}
+}
+
+func (r *Runner) LogDir(testID string) string {
+	return filepath.Join(r.Dir, "logs", testID+"-0")
+}
+
+// New returns a new Runner for executing TTCN-3 tests with k3s backend.
+func New(p project.Interface) (*Runner, error) {
+
+	// Find a nice working directory to put logs and other artifacts in it.
+	dir, err := nttWorkingDir(p)
+	if err != nil {
+		return nil, err
+	}
+
+	// Rebuild the test executable and required adapters first.
+	cmd := nttCommand(p, "build")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	log.Debugf("%s\n%s", cmd, string(out))
+	if err != nil {
+		return nil, &BuildError{
+			Command: cmd,
+			Output:  string(out),
+			Err:     err,
+		}
+	}
+
+	return &Runner{
+		p:   p,
+		Dir: dir,
+	}, nil
+}
+
+// nttWorkingDir returns a working directory for ntt artifacts.
+func nttWorkingDir(p project.Interface) (string, error) {
+
+	root := filepath.Join(fs.Path(p.Root()), "ntt.test")
+	log.Debugf("Working directory: %s", root)
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return root, nil
+	}
+
+	dir, err := ioutil.TempDir("", "ntt-run-")
+	log.Debugf("Creating directory failed. Using %q", dir)
+	return dir, err
+}
+
+// nttCommand will return a exec.Cmd for executing a ntt sub-command.
+// This convencience function sets up common configuration:
+// It will set path to ntt-binary, sets proper test suite arguments, environ
+// variables and working directory.
+func nttCommand(p project.Interface, cmdName string, opts ...string) *exec.Cmd {
+	cmd := exec.Command(nttExecutable())
+
+	// ntt commands have a common format:
+	//     ntt <cmdName> [<args>] [<opts>]
+	cmd.Args = append(cmd.Args, cmdName)
+	cmd.Args = append(cmd.Args, nttArgs(p)...)
+	cmd.Args = append(cmd.Args, opts...)
+
+	if debug := env.Getenv("NTT_DEBUG"); debug != "" {
+		if strings.TrimSpace(strings.ToLower(debug)) == "all" {
+			cmd.Args = append(cmd.Args, "-vvvvv")
+		} else {
+			cmd.Args = append(cmd.Args, "-v")
+		}
+	}
+
+	return cmd
+}
+
+// nttExecutable returns the path to the ntt executable.
+//
+// If no ntt binary is available nttExecutable will return the path of the
+// current executable. This situation happens (for example) when users use a
+// automatically installed ntt binary with no prefix root environment loaded.
+func nttExecutable() string {
+	if exe, err := exec.LookPath("ntt"); err == nil {
+		return exe
+	}
+	if exe, err := os.Executable(); err == nil {
+		return exe
+	}
+	return "ntt"
+}
+
+// nttArgs returns the project root directory. If the project has no root
+// directory nttArgs will return a list of all project source files.
+func nttArgs(p project.Interface) []string {
+	if root := p.Root(); root == "" {
+		return []string{root}
+	}
+
+	srcs, _ := project.Files(p)
+	return srcs
+}
+
+// nttEnv returns the magic environment variables required to use ntt with
+// Nokia component tests.
+func nttEnv(p project.Interface) []string {
+
+	// SCTs use environment variable `NTT_CACHE` to find various required
+	// files. For example file `k3.env`, which is required for the SCTs to
+	// function correctly.
+	return append(os.Environ(), "NTT_CACHE="+strings.Join(func(p project.Interface) []string {
+		dirs := strings.Split(env.Getenv("NTT_CACHE"), ":")
+		if path := fs.FindK3EnvInCurrPath(fs.Path(p.Root())); path != "" {
+			dirs = append(dirs, path)
+		}
+		return dirs
+	}(p), ":"))
+}
+
+type BuildError struct {
+	Command *exec.Cmd
+	Output  string
+	Err     error
+}
+
+func (e *BuildError) Error() string {
+	return e.Err.Error()
+}

--- a/vendor/github.com/acarl005/stripansi/LICENSE
+++ b/vendor/github.com/acarl005/stripansi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Andrew Carlson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/acarl005/stripansi/README.md
+++ b/vendor/github.com/acarl005/stripansi/README.md
@@ -1,0 +1,30 @@
+Strip ANSI
+==========
+
+This Go package removes ANSI escape codes from strings.
+
+Ideally, we would prevent these from appearing in any text we want to process.
+However, sometimes this can't be helped, and we need to be able to deal with that noise.
+This will use a regexp to remove those unwanted escape codes.
+
+
+## Install
+
+```sh
+$ go get -u github.com/acarl005/stripansi
+```
+
+## Usage
+
+```go
+import (
+	"fmt"
+	"github.com/acarl005/stripansi"
+)
+
+func main() {
+	msg := "\x1b[38;5;140m foo\x1b[0m bar"
+	cleanMsg := stripansi.Strip(msg)
+	fmt.Println(cleanMsg) // " foo bar"
+}
+```

--- a/vendor/github.com/acarl005/stripansi/stripansi.go
+++ b/vendor/github.com/acarl005/stripansi/stripansi.go
@@ -1,0 +1,13 @@
+package stripansi
+
+import (
+	"regexp"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var re = regexp.MustCompile(ansi)
+
+func Strip(str string) string {
+	return re.ReplaceAllString(str, "")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,5 @@
+# github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+github.com/acarl005/stripansi
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/golang/protobuf v1.4.2


### PR DESCRIPTION
This commit moves test execution into a dedicated package. This is a
first step of making test execution asynchronous.

This commit also exports some Templates from ntt-report command for
making programmatic report generation easier.