### PR TITLE
Fix Nokia runner

### DIFF
--- a/cmd/ntt/main.go
+++ b/cmd/ntt/main.go
@@ -101,7 +101,24 @@ func init() {
 	rootCmd.AddCommand(tags.Command)
 	rootCmd.AddCommand(report.Command)
 
-	if exe, _ := exec.LookPath("k3-run"); exe == "" || os.Getenv("K3_40_RUN_POLICY") != "old" {
+	useNokiaRunner := func() bool {
+		if s, ok := os.LookupEnv("K3_40_RUN_POLICY"); ok {
+			if s == "ntt" {
+				return false
+			}
+			return true
+		}
+		if exe, _ := exec.LookPath("k3-run"); exe != "" {
+			return true
+		}
+		if exe, _ := exec.LookPath("ntt-run"); exe != "" {
+			return true
+		}
+		return false
+
+	}
+
+	if !useNokiaRunner() {
 		rootCmd.AddCommand(run.Command)
 	}
 


### PR DESCRIPTION
Nokia uses a custom runner internally. This internal runner was never
called, because ntt's run command registered as soon as environment
variable `K3_40_RUN_POLICY` was not set.

This commit fixes the condition and make improves its readability to
prevent similar issues in the future.