### PR TITLE
Replace timeout test

### DIFF
--- a/k3/run/run_test.go
+++ b/k3/run/run_test.go
@@ -89,10 +89,10 @@ func TestEvents(t *testing.T) {
 				"tciError error (id not fully qualified)",
 			}},
 		{
-			input:   "math.Test",
+			input:   "test.D",
 			timeout: 1 * time.Second,
 			events: []string{
-				`tciTestCaseStarted math.Test`,
+				`tciTestCaseStarted test.D`,
 				`tciError error (timeout)`,
 			}},
 	}

--- a/k3/run/testdata/suite/test.ttcn3
+++ b/k3/run/testdata/suite/test.ttcn3
@@ -13,6 +13,11 @@ module test {
 		log(23/0); // should cause an error
 	}
 
+	testcase D() runs on MTC {
+		setverdict(pass, "success");
+		wait(20.0 + now);
+	}
+
 	control {
 		execute(B());
 		execute(A());


### PR DESCRIPTION
The previous testcase `math.Test` stopped being available in T3XF file.
Background:

k3-build script did not pass imported TTCN-3 files to the compiler, but
the ntt build command did.
This caused problems ("no such module PCMDmod") when developer at Nokia
started importing k3 plugins directly.