### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -1,23 +1,10 @@
 package session
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func tempStorage() (*storage, func()) {
-	dir, err := ioutil.TempDir("", "storage.test")
-	if err != nil {
-		panic(err.Error())
-	}
-	s, _ := New(dir)
-	return s, func() {
-		os.RemoveAll(dir)
-	}
-}
 
 func TestEmptyStorage(t *testing.T) {
 	s, _ := New(".")

--- a/k3/k3_test.go
+++ b/k3/k3_test.go
@@ -2,7 +2,6 @@ package k3_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,8 +17,7 @@ func TestNewPlugin(t *testing.T) {
 		t.Skip("Cannot locate k3 runtime. Skipping test.")
 	}
 
-	srcdir, _, cleanup := initStage(t)
-	defer cleanup()
+	srcdir, _ := initStage(t)
 
 	b := k3.NewPlugin(k3.DefaultEnv, "extfunc", filepath.Join(srcdir, "testdata/suite/extfunc/plugin.cc"))[0]
 	err := b.Run()
@@ -52,8 +50,7 @@ func TestNewT3XF(t *testing.T) {
 	if k3.Compiler() == "mtc" {
 		t.Skip("Cannot locate k3 compiler. Skipping test.")
 	}
-	srcdir, _, cleanup := initStage(t)
-	defer cleanup()
+	srcdir, _ := initStage(t)
 
 	b := k3.NewT3XF(k3.DefaultEnv, "suite.t3xf", filepath.Join(srcdir, "testdata/suite/test.ttcn3"))[0]
 	err := b.Run()
@@ -78,11 +75,8 @@ func TestNewT3XF(t *testing.T) {
 	}
 }
 
-func initStage(t *testing.T) (string, string, func()) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+func initStage(t *testing.T) (string, string) {
+	dir := t.TempDir()
 	old, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -95,10 +89,11 @@ func initStage(t *testing.T) (string, string, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return old, dir, func() {
+	t.Cleanup(func() {
 		os.Chdir(old)
-		os.RemoveAll(dir)
-	}
+	})
+
+	return old, dir
 }
 
 func sliceContains(s []string, x string) bool {

--- a/k3/run/run_test.go
+++ b/k3/run/run_test.go
@@ -2,7 +2,6 @@ package run_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,8 +14,7 @@ import (
 )
 
 func TestEvents(t *testing.T) {
-	old, _, cancel := initStage(t)
-	defer cancel()
+	old, _ := initStage(t)
 
 	t3xf := testBuild(t, filepath.Join(old, "testdata/suite"))
 
@@ -116,11 +114,8 @@ func TestEvents(t *testing.T) {
 
 }
 
-func initStage(t *testing.T) (string, string, func()) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+func initStage(t *testing.T) (string, string) {
+	dir := t.TempDir()
 	old, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -133,10 +128,11 @@ func initStage(t *testing.T) (string, string, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return old, dir, func() {
+	t.Cleanup(func() {
 		os.Chdir(old)
-		os.RemoveAll(dir)
-	}
+	})
+
+	return old, dir
 }
 
 func testBuild(t *testing.T, args ...string) string {


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```