### PR TITLE
Pass import-directories instead of files

### DIFF
--- a/k3/k3_test.go
+++ b/k3/k3_test.go
@@ -52,7 +52,7 @@ func TestNewT3XF(t *testing.T) {
 	}
 	srcdir, _ := initStage(t)
 
-	b := k3.NewT3XF(k3.DefaultEnv, "suite.t3xf", filepath.Join(srcdir, "testdata/suite/test.ttcn3"))[0]
+	b := k3.NewT3XF(k3.DefaultEnv, "suite.t3xf", []string{filepath.Join(srcdir, "testdata/suite/test.ttcn3")})[0]
 	err := b.Run()
 	if err != nil {
 		t.Errorf("Run() = %v", err)

--- a/k3/run/run_test.go
+++ b/k3/run/run_test.go
@@ -84,10 +84,10 @@ func TestEvents(t *testing.T) {
 				"tciError error (id not fully qualified)",
 			}},
 		{
-			input:   "math.Test",
+			input:   "test.D",
 			timeout: 1 * time.Second,
 			events: []string{
-				`tciTestCaseStarted math.Test`,
+				`tciTestCaseStarted test.D`,
 				`tciError error (timeout)`,
 			}},
 	}

--- a/project/project.go
+++ b/project/project.go
@@ -364,15 +364,17 @@ func BuildTasks(c *Config) ([]Task, error) {
 	if err != nil {
 		merr = multierror.Append(merr, err)
 	}
+
+	var imports []string
 	for _, t := range ret {
 		for _, output := range t.Outputs() {
 			if fs.HasTTCN3Extension(output) {
-				srcs = append(srcs, output)
+				imports = append(imports)
 			}
 		}
 	}
 
-	for _, t := range k3.NewT3XF(c.Variables, c.K3.T3XF, srcs...) {
+	for _, t := range k3.NewT3XF(c.Variables, c.K3.T3XF, srcs, imports...) {
 		ret = append(ret, t)
 	}
 

--- a/project/project.go
+++ b/project/project.go
@@ -369,7 +369,7 @@ func BuildTasks(c *Config) ([]Task, error) {
 	for _, t := range ret {
 		for _, output := range t.Outputs() {
 			if fs.HasTTCN3Extension(output) {
-				imports = append(imports)
+				imports = append(imports, output)
 			}
 		}
 	}


### PR DESCRIPTION
Some TTCN-3 libraries contain TTCN-3 files which must not included. This commit does not pass imported files to the internal Nokia compiler, but imported directories instead.

Please note, that resulting T3XF might not be complete, because current compiler only includes modules which are imported by a source file.