### PR TITLE
💄

### DIFF
--- a/cmd/ntt/run.go
+++ b/cmd/ntt/run.go
@@ -181,7 +181,7 @@ L:
 			log.Debugf("result: jobID=%s, event=%#v\n", res.Job.ID(), res.Event)
 
 			// Track errors for early exit (aka --max-fail).
-			if tests.IsFail(res.Event) {
+			if !tests.IsPass(res.Event) {
 				errorCount++
 			}
 

--- a/internal/lsp/commands.go
+++ b/internal/lsp/commands.go
@@ -27,9 +27,8 @@ func NewCommand(pos loc.Position, title string, command string, args ...interfac
 }
 
 type nttTestParams struct {
-	ID   string // Fully qualified testcase identifier
-	URI  string // URL points to the ttcn3 source file containing the testcase
-	Stop bool   // Stop the test
+	TestID      // TestID identifies a testcase in a ttch3 source file.
+	Stop   bool // Stop the test
 }
 
 func (s *Server) executeCommand(ctx context.Context, params *protocol.ExecuteCommandParams) (interface{}, error) {
@@ -39,20 +38,12 @@ func (s *Server) executeCommand(ctx context.Context, params *protocol.ExecuteCom
 	case "ntt.status":
 		return s.status(ctx)
 	case "ntt.test":
-		var param nttTestParams
-		if err := unmarshalRaw(params.Arguments, &param); err != nil {
+		var tp nttTestParams
+		if err := unmarshalRaw(params.Arguments, &tp); err != nil {
 			return nil, err
 		}
 
-		// A file might belong to multiple test suites, possibly. But
-		// it's sufficient to just take the first test suite available,
-		// practically.
-		suite, err := s.FirstSuite(param.URI)
-		if err != nil {
-			return nil, err
-		}
-
-		return nil, s.testCtrl.RunTest(suite.Config, param.ID, s)
+		return nil, s.testCtrl.RunTest(tp.TestID)
 	}
 	return nil, nil
 }

--- a/internal/lsp/controller.go
+++ b/internal/lsp/controller.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 
 	"github.com/nokia/ntt/internal/fs"
+	"github.com/nokia/ntt/internal/loc"
 	"github.com/nokia/ntt/internal/log"
 	"github.com/nokia/ntt/internal/lsp/protocol"
 	"github.com/nokia/ntt/k3/k3s"
-	"github.com/nokia/ntt/project"
 	"github.com/nokia/ntt/tests"
 )
 
@@ -19,98 +19,147 @@ type TestController struct {
 	// messages is the channel where test events are sent.
 	messages chan tests.Event
 
-	running map[key]bool
-	mu      sync.Mutex
+	// jobs maps id and test jobs.
+	//
+	// It assures that a test is not executed twice, because the CodeLens
+	// UI can only display one "run test" button at a time.
+	jobs map[TestID]*tests.Job
+	mu   sync.Mutex
 
 	// client is the LSP client. It is used to send notifications and
 	// status updates to the IDE.
 	client protocol.Client
+
+	// console is used to display test output.
+	console io.Writer
+
+	// suites is required to find test suite configurations for a given test.
+	suites *Suites
 }
 
-type key struct {
-	name   string
-	config *project.Config
+type TestID struct {
+	URI  string
+	Name string
+	Pos  loc.Pos
 }
 
-func (c *TestController) Start(client protocol.Client) error {
+// Start starts the test controller.
+func (c *TestController) Start(client protocol.Client, logger io.Writer, suites *Suites) error {
 	c.messages = make(chan tests.Event)
-	c.running = make(map[key]bool)
+	c.jobs = make(map[TestID]*tests.Job)
 	c.client = client
-	go c.handleEvents()
+	c.console = logger
+	c.suites = suites
+	go func() {
+		for event := range c.messages {
+			log.Debugf("TestController: %+v\n", event)
+			switch e := event.(type) {
+			case tests.StartEvent:
+			case tests.StopEvent, tests.ErrorEvent:
+				if job := tests.UnwrapJob(e); job != nil {
+					c.removeJob(job)
+				}
+			default:
+				log.Debugf("TestController: unknown event: %T\n", e)
+			}
+			c.client.CodeLensRefresh(context.Background())
+		}
+	}()
 	return nil
 }
 
+// Shutdown stops the test controller.
 func (c *TestController) Shutdown() error {
 	close(c.messages)
 	return nil
 }
 
-func (c *TestController) handleEvents() {
-	for event := range c.messages {
-		log.Debugf("TestController: %+v", event)
-		c.mu.Lock()
-		switch e := event.(type) {
-		case tests.StartEvent:
-		case tests.StopEvent, tests.ErrorEvent:
-			if job := tests.UnwrapJob(e); job != nil {
-				delete(c.running, key{job.Name, job.Config})
-			}
-		default:
-			log.Debugf("TestController: unknown event")
-		}
-		c.mu.Unlock()
-		c.client.CodeLensRefresh(context.Background())
-	}
+// IsRunning returns true if a test is already scheduled for execution.
+func (c *TestController) IsRunning(id TestID) bool {
+	return c.lookupJob(id) != nil
 }
 
-func (c *TestController) IsRunning(config *project.Config, name string) bool {
+// RunTest schedules a test for execution.
+func (c *TestController) RunTest(id TestID) error {
+
+	// Check if the test is already running.
+	if job := c.lookupJob(id); job != nil {
+		return fmt.Errorf("test %s already running", job.Name)
+	}
+
+	// First we need determine the runtime configuration.
+	// If we find multiple configuration, we don't ask the user to choose but just the last candidate.
+	// The assumption is: The the latest configuration has a higher probability to be the complete one.
+	candidates := c.suites.Owners(protocol.DocumentURI(id.URI))
+	if len(candidates) == 0 {
+		return fmt.Errorf("cannot run %s: no configuration found", id.URI)
+	}
+	if len(candidates) > 1 {
+		log.Printf("multiple configurations found for %s: %v\n", id.URI, candidates)
+	}
+	config := candidates[0].Config
+	log.Printf("using configuration from %s", config.Root)
+
+	// TODO(5nord): Use project.ApplyPreset to retrieve the configuration,
+	// like expected verdict for the job.
+	c.enqueueJob(id, &tests.Job{
+		Name:   id.Name,
+		Config: config,
+	})
+	return nil
+}
+
+// job returns the test job for the given id.
+func (c *TestController) lookupJob(id TestID) *tests.Job {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.running[key{name, config}]
+	return c.jobs[id]
 }
 
-func (c *TestController) RunTest(config *project.Config, name string, logger io.Writer) error {
-	if c.IsRunning(config, name) {
-		return fmt.Errorf("test %s already running", name)
+// remove removes the test job from the controller.
+func (c *TestController) removeJob(job *tests.Job) {
+	for id, j := range c.jobs {
+		if j == job {
+			c.mu.Lock()
+			delete(c.jobs, id)
+			c.mu.Unlock()
+			return
+		}
 	}
+}
 
-	job := &tests.Job{
-		Name:   name,
-		Config: config,
-	}
-
+func (c *TestController) enqueueJob(id TestID, job *tests.Job) {
 	c.mu.Lock()
-	c.running[key{name, config}] = true
+	c.jobs[id] = job
 	c.mu.Unlock()
-	c.messages <- tests.NewStartEvent(job, name)
+	c.messages <- tests.NewStartEvent(job, job.Name)
 
 	go func() {
-		fmt.Fprintf(logger, `
+		fmt.Fprintf(c.console, `
 ===============================================================================
-Compiling test %s in %q`, name, config.Root)
+Compiling test %s in %q`, job.Name, job.Config.Root)
 
-		if err := k3s.Build(logger, config); err != nil {
-			fmt.Fprintln(logger, err.Error())
+		if err := k3s.Build(c.console, job.Config); err != nil {
+			fmt.Fprintln(c.console, err.Error())
 			c.messages <- tests.NewErrorEvent(&tests.JobError{Job: job, Err: err})
 			return
 		}
 
-		fmt.Fprintf(logger, `
+		fmt.Fprintf(c.console, `
 ===============================================================================
-Running test %s in %q`, name, config.Root)
+Running test %s in %q`, job.Name, job.Config.Root)
 
-		logDir, _ := k3s.Run(logger, config, name)
+		logDir, _ := k3s.Run(c.console, job.Config, job.Name)
 
 		if files := fs.Abs(fs.FindFilesRecursive(logDir)...); len(files) > 0 {
-			fmt.Fprintf(logger, `
+			fmt.Fprintf(c.console, `
 Content of log directory %q:
 ===============================================================================
 %s
 `,
 				logDir, strings.Join(files, "\n"))
 		}
-		c.messages <- tests.NewStopEvent(job, name, "")
+		c.messages <- tests.NewStopEvent(job, job.Name, "")
 	}()
 
-	return nil
 }

--- a/internal/lsp/controller.go
+++ b/internal/lsp/controller.go
@@ -88,8 +88,10 @@ func (c *TestController) RunTest(id TestID) error {
 	}
 
 	// First we need determine the runtime configuration.
-	// If we find multiple configuration, we don't ask the user to choose but just the last candidate.
-	// The assumption is: The the latest configuration has a higher probability to be the complete one.
+	//
+	// If we find multiple configurations, we don't ask the user to choose,
+	// but simply use the last candidate. The assumption is: The latest
+	// configuration has a higher probability to be the complete one.
 	candidates := c.suites.Owners(protocol.DocumentURI(id.URI))
 	if len(candidates) == 0 {
 		return fmt.Errorf("cannot run %s: no configuration found", id.URI)

--- a/internal/lsp/general.go
+++ b/internal/lsp/general.go
@@ -105,7 +105,7 @@ func (s *Server) initialized(ctx context.Context, params *protocol.InitializedPa
 	}
 
 	s.testCtrl = &TestController{}
-	s.testCtrl.Start(s.client)
+	s.testCtrl.Start(s.client, s, &s.Suites)
 	return nil
 }
 

--- a/internal/lsp/suites.go
+++ b/internal/lsp/suites.go
@@ -124,15 +124,6 @@ type Suites struct {
 	db ttcn3.DB
 }
 
-// FirstSuite returns the first test suite owning the file or an error if not
-// owning suite was found.
-func (s *Suites) FirstSuite(uri string) (*Suite, error) {
-	if suites := s.Owners(protocol.DocumentURI(uri)); len(suites) > 0 {
-		return suites[0], nil
-	}
-	return nil, fmt.Errorf("File %q seem not to belong to any test suite. Skipping execution.", uri)
-}
-
 // Owners returns all Suites that require the opened file.
 func (s *Suites) Owners(uri protocol.DocumentURI) []*Suite {
 	s.mu.Lock()


### PR DESCRIPTION
* Rename IsFail to IsPass: Makes it easier to understand it's purpose
* Separating test case execution and IsRunning-Policy: Makes it easier to merge test case controllers.
