### PR TITLE
Fix bug in ntt report

### DIFF
--- a/internal/results/results.go
+++ b/internal/results/results.go
@@ -16,7 +16,7 @@ import (
 func Latest() (*DB, error) {
 	b, err := fs.Open("test_results.json").Bytes()
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if os.IsNotExist(err) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
ntt tries to unmarshall the bytes even when test_results.json was not
found in the filesystem.