### PR TITLE
Refactor ntt run

### DIFF
--- a/cmd/ntt/run.go
+++ b/cmd/ntt/run.go
@@ -128,14 +128,6 @@ func run(cmd *cobra.Command, args []string) error {
 	ctx, cancel := WithSignalHandler(context.Background())
 	defer cancel()
 
-	// Setup baskets
-	var err error
-	Basket, err = ntt.NewBasketWithFlags("list", cmd.Flags())
-	Basket.LoadFromEnvOrConfig(Project, "NTT_LIST_BASKETS")
-	if err != nil {
-		return err
-	}
-
 	// Build Suite and collect runtime directories.
 	suite, err := ntt.NewSuite(Project)
 	if err != nil {
@@ -311,7 +303,13 @@ func k3sJobs(jobs <-chan *ntt.Job) io.Reader {
 }
 
 // GenerateIDs emits test IDs based on given file and and id list to a channel.
-func GenerateIDs(ctx context.Context, ids []string, files []string, policy string, b ntt.Basket) <-chan string {
+func GenerateIDs(ctx context.Context, ids []string, files []string, policy string) (<-chan string, error) {
+	b, err := ntt.NewBasketWithFlags("list", cmd.Flags())
+	b.LoadFromEnvOrConfig(Project, "NTT_LIST_BASKETS")
+	if err != nil {
+		return err
+	}
+
 	policy = strings.ToLower(policy)
 	policy = strings.TrimSpace(policy)
 	switch {

--- a/cmd/ntt/run.go
+++ b/cmd/ntt/run.go
@@ -128,13 +128,6 @@ func run(cmd *cobra.Command, args []string) error {
 	ctx, cancel := WithSignalHandler(context.Background())
 	defer cancel()
 
-	// Init
-	if OutputDir != "" {
-		if err := os.MkdirAll(OutputDir, os.ModePerm); err != nil {
-			return fmt.Errorf("creating logs directory failed: %w", err)
-		}
-	}
-
 	// Setup baskets
 	var err error
 	Basket, err = ntt.NewBasketWithFlags("list", cmd.Flags())

--- a/cmd/ntt/run.go
+++ b/cmd/ntt/run.go
@@ -148,7 +148,7 @@ func run(cmd *cobra.Command, args []string) error {
 		ids = append(tests, ids...)
 	}
 
-	ledger := ntt.NewLedger(MaxWorkers)
+	ledger := ntt.NewRunner(MaxWorkers)
 	jobs, err := GenerateJobs(ctx, suite, ids, MaxWorkers, ledger)
 	if err != nil {
 		return err
@@ -160,7 +160,7 @@ func run(cmd *cobra.Command, args []string) error {
 	return nttRun(ctx, jobs, ledger)
 }
 
-func nttRun(ctx context.Context, jobs <-chan *ntt.Job, ledger *ntt.Ledger) error {
+func nttRun(ctx context.Context, jobs <-chan *ntt.Job, ledger *ntt.Runner) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -316,7 +316,7 @@ func GenerateIDs(ctx context.Context, ids []string, files []string, policy strin
 }
 
 // GenerateJobs emits jobs from the given suite and ids to a job channel.
-func GenerateJobs(ctx context.Context, suite *ntt.Suite, ids []string, size int, ledger *ntt.Ledger) (chan *ntt.Job, error) {
+func GenerateJobs(ctx context.Context, suite *ntt.Suite, ids []string, size int, ledger *ntt.Runner) (chan *ntt.Job, error) {
 	srcs, err := fs.TTCN3Files(suite.Sources...)
 	if err != nil {
 		return nil, err
@@ -329,7 +329,7 @@ func GenerateJobs(ctx context.Context, suite *ntt.Suite, ids []string, size int,
 		i := 0
 		for id := range GenerateIDs(ctx, ids, srcs, env.Getenv("K3_40_RUN_POLICY"), Basket) {
 			i++
-			out <- ledger.NewJob(id, suite)
+			out <- ledger.EnqueueJob(id, suite)
 		}
 		log.Debugf("Generating %d jobs done.\n", i)
 	}()

--- a/ntt.go
+++ b/ntt.go
@@ -464,7 +464,7 @@ func (l *Runner) EnqueueJob(name string, suite *Suite) *Job {
 	return &job
 }
 
-func (l *Runner) Done(job *Job) {
+func (l *Runner) JobDone(job *Job) {
 	l.Lock()
 	defer l.Unlock()
 	delete(l.jobs, job.id)
@@ -509,7 +509,7 @@ func (l *Runner) Run(ctx context.Context, jobs <-chan *Job) <-chan Result {
 // execute runs a single test and sends the results to the channel.
 func (l *Runner) run(ctx context.Context, job *Job, results chan<- Result) {
 
-	defer l.Done(job)
+	defer l.JobDone(job)
 	var (
 		workingDir string
 		logFile    string

--- a/ntt.go
+++ b/ntt.go
@@ -492,7 +492,7 @@ func (l *Runner) Run(ctx context.Context, jobs <-chan *Job) <-chan Result {
 			defer log.Debugf("Worker %d finished.\n", i)
 
 			for job := range jobs {
-				l.run(ctx, job, results)
+				l.execute(ctx, job, results)
 			}
 		}(i)
 	}
@@ -507,7 +507,7 @@ func (l *Runner) Run(ctx context.Context, jobs <-chan *Job) <-chan Result {
 }
 
 // execute runs a single test and sends the results to the channel.
-func (l *Runner) run(ctx context.Context, job *Job, results chan<- Result) {
+func (l *Runner) execute(ctx context.Context, job *Job, results chan<- Result) {
 
 	defer l.JobDone(job)
 	var (


### PR DESCRIPTION
Current ntt run implementation is mostly a transcript of the Nokia internal bash script `k3-run`. Accordingly it's very hacky with insuffienct test coverage.

This PR aims to fix that.
