### PR TITLE
Fix NewList Behaviour

### DIFF
--- a/builtins/match.go
+++ b/builtins/match.go
@@ -43,7 +43,7 @@ func matchRecord(a, b *runtime.Record) (bool, error) {
 // matchSetOf returns true given sets match.
 func matchSetOf(a, b *runtime.List) (bool, error) {
 	containsStar := false
-	temp := runtime.NewList(len(b.Elements))
+	temp := runtime.NewSetOf()
 	for _, y := range b.Elements {
 		if y == runtime.AnyOrNone {
 			containsStar = true

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -350,7 +350,7 @@ func evalValueList(s []ast.Expr, env runtime.Scope) runtime.Object {
 	if len(objs) == 1 && runtime.IsError(objs[0]) {
 		return objs[0]
 	}
-	l := runtime.NewList(len(objs))
+	l := runtime.NewList(0)
 	l.Elements = objs
 	return l
 }

--- a/runtime/object.go
+++ b/runtime/object.go
@@ -311,7 +311,11 @@ func (l *List) Equal(obj Object) bool {
 }
 
 func NewList(i int) *List {
-	return &List{Elements: make([]Object, i)}
+	l := &List{}
+	for ; i > 0; i-- {
+		l.Elements = append(l.Elements, Undefined)
+	}
+	return l
 }
 
 func NewRecordOf() *List {

--- a/runtime/object.go
+++ b/runtime/object.go
@@ -310,9 +310,11 @@ func (l *List) Equal(obj Object) bool {
 	return EqualObjects(l.Elements, other.Elements)
 }
 
-func NewList(i int) *List {
+// NewList creates a new ordered list. If a size greater than zero is given,
+// NewList will initialize the List with runtime.Undefined objects.
+func NewList(size int) *List {
 	l := &List{}
-	for ; i > 0; i-- {
+	for ; size > 0; size-- {
 		l.Elements = append(l.Elements, Undefined)
 	}
 	return l


### PR DESCRIPTION
When creating a list with a specific size, NewList did not assign `runtime.Undefined` to its fields. The nil pointer caused a panic when accessed.