### PR TITLE
Fix handling missing test_result.json

### DIFF
--- a/internal/results/results.go
+++ b/internal/results/results.go
@@ -16,9 +16,10 @@ import (
 func Latest() (*DB, error) {
 	b, err := fs.Open("test_results.json").Bytes()
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return nil, err
+		if os.IsNotExist(err) {
+			return &DB{}, nil
 		}
+		return nil, err
 	}
 	var db DB
 	return &db, json.Unmarshal(b, &db)


### PR DESCRIPTION
Return an empty `results.DB` structure, when no test_result.json file is
available.

Function `results.Latest` is supposed to return an empty structure, when
no test_result.json is available. However, `json.Unmarshal` returns an
error for empty bytes slices, which is was not intended behaviour.