### PR TITLE
adding builtin function int2bin

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -31,6 +31,32 @@ func Rnd(args ...runtime.Object) runtime.Object {
 	return runtime.Float(rand.Float64())
 }
 
+func Int2Bit(args ...runtime.Object) runtime.Object {
+
+	if len(args) != 2 {
+		return runtime.Errorf("wrong number of arguments. got=%d, want=2", len(args))
+	}
+
+	number, ok := args[0].(runtime.Int)
+	if !ok {
+		return runtime.Errorf("%s arguments not supported", args[0].Type())
+	}
+	if number.Sign() == -1 {
+		return runtime.Errorf("%s invalue is less than zero", args[0].Type())
+	}
+
+	lengthArg, lenOk := args[1].(runtime.Int)
+	if !lenOk {
+		return runtime.Errorf("%s arguments not supported", args[1].Type())
+	}
+	length := int(lengthArg.Uint64());
+	if number.BitLen() > length {
+		return runtime.Errorf("%v value requires more than %d bits", number, length)
+	}
+
+	return &runtime.Bitstring{Value: number.Value(), Unit: runtime.Bit, Padding: 4}
+}
+
 func Int2Float(args ...runtime.Object) runtime.Object {
 	if len(args) != 1 {
 		return runtime.Errorf("wrong number of arguments. got=%d, want=1", len(args))
@@ -90,6 +116,7 @@ func makeSet(lt runtime.ListType, args ...runtime.Object) func(...runtime.Object
 func init() {
 	runtime.AddBuiltin("lengthof", Lengthof)
 	runtime.AddBuiltin("rnd", Rnd)
+	runtime.AddBuiltin("int2bit", Int2Bit)
 	runtime.AddBuiltin("int2float", Int2Float)
 	runtime.AddBuiltin("float2int", Float2Int)
 	runtime.AddBuiltin("log", Log)

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -36,7 +36,6 @@ func Int2Bit(args ...runtime.Object) runtime.Object {
 	if len(args) != 2 {
 		return runtime.Errorf("wrong number of arguments. got=%d, want=2", len(args))
 	}
-
 	number, ok := args[0].(runtime.Int)
 	if !ok {
 		return runtime.Errorf("%s arguments not supported", args[0].Type())
@@ -44,17 +43,21 @@ func Int2Bit(args ...runtime.Object) runtime.Object {
 	if number.Sign() == -1 {
 		return runtime.Errorf("%s invalue is less than zero", args[0].Type())
 	}
-
 	lengthArg, lenOk := args[1].(runtime.Int)
 	if !lenOk {
 		return runtime.Errorf("%s arguments not supported", args[1].Type())
 	}
-	length := int(lengthArg.Uint64());
+	if !lengthArg.IsInt64() {
+		return runtime.Errorf("length argument out of range (int64)")
+	}
+	length := int(lengthArg.Int64())
 	if number.BitLen() > length {
 		return runtime.Errorf("%v value requires more than %d bits", number, length)
 	}
-
-	return &runtime.Bitstring{Value: number.Value(), Unit: runtime.Bit, Padding: 4}
+	if length < 0 {
+		return runtime.Errorf("length must be greater or equal than zero")
+	}
+	return &runtime.Bitstring{Value: number.Value(), Unit: runtime.Bit, Length: length}
 }
 
 func Int2Float(args ...runtime.Object) runtime.Object {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -313,7 +313,7 @@ func evalLiteral(n *ast.ValueLiteral, env runtime.Scope) runtime.Object {
 		}
 		return &runtime.String{Value: []rune(s)}
 	case token.BSTRING:
-		b, err := runtime.NewBitstring(n.Tok.Lit)
+		b, err := runtime.NewBitstring(n.Tok.Lit, true)
 		if err != nil {
 			return runtime.Errorf("%s", err.Error())
 		}

--- a/runtime/object.go
+++ b/runtime/object.go
@@ -222,20 +222,20 @@ func NewString(s string) *String {
 }
 
 type Bitstring struct {
-	Value *big.Int
-	Unit  Unit
-	Padding Unit
+	Value  *big.Int
+	Unit   Unit
+	Length int
 }
 
 func (b *Bitstring) Type() ObjectType { return BITSTRING }
 func (b *Bitstring) Inspect() string {
 	switch b.Unit {
 	case Bit:
-		return fmt.Sprintf("'%0*b'B", b.Padding, b.Value)
+		return fmt.Sprintf("'%0*b'B", b.Length, b.Value)
 	case Octett:
-		return fmt.Sprintf("'%0*h'O", b.Padding, b.Value)
+		return fmt.Sprintf("'%0*h'O", b.Length, b.Value)
 	default:
-		return fmt.Sprintf("'%0*h'H", b.Padding, b.Value)
+		return fmt.Sprintf("'%0*h'H", b.Length, b.Value)
 	}
 }
 
@@ -252,7 +252,8 @@ func (b *Bitstring) hashKey() hashKey {
 	return hashKey{Type: b.Type(), Value: h.Sum64()}
 }
 
-func NewBitstring(s string) (*Bitstring, error) {
+func NewBitstring(s string, trim bool) (*Bitstring, error) {
+
 	if len(s) < 3 || s[0] != '\'' || s[len(s)-2] != '\'' {
 		return nil, ErrSyntax
 	}
@@ -269,17 +270,19 @@ func NewBitstring(s string) (*Bitstring, error) {
 		return nil, ErrSyntax
 	}
 
-	payloadLen := Unit(len(s)) - 3
-	removeWhitespaces := func(r rune) rune {
-		if unicode.IsSpace(r) {
-			return -1
+	trimFunc := func(r rune) bool {
+		if trim {
+			return unicode.IsSpace(r) || r == '0'
 		}
-		return r
+		return unicode.IsSpace(r)
 	}
-	s = strings.Map(removeWhitespaces, s[1:len(s)-2])
+
+	s = s[1 : len(s)-2]
+	s = strings.TrimFunc(s, trimFunc)
+	length := len(s)
 
 	if i, ok := new(big.Int).SetString(s, unit.Base()); ok {
-		return &Bitstring{Value: i, Unit: unit, Padding: payloadLen}, nil
+		return &Bitstring{Value: i, Unit: unit, Length: length}, nil
 	}
 
 	// TODO(5nord) parse and return Bitstring templates (e.g. '01*1'B)

--- a/runtime/object.go
+++ b/runtime/object.go
@@ -224,17 +224,18 @@ func NewString(s string) *String {
 type Bitstring struct {
 	Value *big.Int
 	Unit  Unit
+	Padding Unit
 }
 
 func (b *Bitstring) Type() ObjectType { return BITSTRING }
 func (b *Bitstring) Inspect() string {
 	switch b.Unit {
 	case Bit:
-		return fmt.Sprintf("'%b'B", b.Value)
+		return fmt.Sprintf("'%0*b'B", b.Padding, b.Value)
 	case Octett:
-		return fmt.Sprintf("'%h'O", b.Value)
+		return fmt.Sprintf("'%0*h'O", b.Padding, b.Value)
 	default:
-		return fmt.Sprintf("'%h'H", b.Value)
+		return fmt.Sprintf("'%0*h'H", b.Padding, b.Value)
 	}
 }
 
@@ -268,6 +269,7 @@ func NewBitstring(s string) (*Bitstring, error) {
 		return nil, ErrSyntax
 	}
 
+	payloadLen := Unit(len(s)) - 3
 	removeWhitespaces := func(r rune) rune {
 		if unicode.IsSpace(r) {
 			return -1
@@ -277,7 +279,7 @@ func NewBitstring(s string) (*Bitstring, error) {
 	s = strings.Map(removeWhitespaces, s[1:len(s)-2])
 
 	if i, ok := new(big.Int).SetString(s, unit.Base()); ok {
-		return &Bitstring{Value: i, Unit: unit}, nil
+		return &Bitstring{Value: i, Unit: unit, Padding: payloadLen}, nil
 	}
 
 	// TODO(5nord) parse and return Bitstring templates (e.g. '01*1'B)


### PR DESCRIPTION
this is my first commit to this repo.
Please check it carefully.

Changes to runtime/object.go are up for discussion - motivation for this part is in 'padding' from spec (see below)

https://www.etsi.org/deliver/etsi_es/201800_201899/20187301/04.07.01_60/es_20187301v040701p.pdf

ETSI ES 201 873-1 V4.7.1 (2015-06)
page 288

> C.1.3 Integer to bitstring
int2bit(in integer invalue, in integer length) return bitstring
This function converts a single integer value to a single bitstring value. 
The resulting string is length bits long.
For the purposes of this conversion, a bitstring shall be interpreted as a positive base 2 integer value.
The rightmost bit is least significant, the leftmost bit is the most significant. 
The bits 0 and 1 represent the decimal values 0 and 1 respectively.
If the conversion yields a value with fewer bits than specified in the length parameter, then the bitstring shall be padded on the left with zeros.
In addition to the general error causes in clause 16.1.2, error causes are:
• invalue is less than zero;
• the conversion yields a return value with more bits than specified by length. 