### PR TITLE
unichar2int AND int2unichar

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -504,3 +504,81 @@ func TestBuiltinFunctionInt2char(t *testing.T) {
 		}
 	}
 }
+
+func TestBuiltinFunctionInt2unichar(t *testing.T) {
+
+	tests := []struct {
+		input    string
+		expected runtime.Object
+	}{
+		{`int2unichar()`, runtime.Errorf("wrong number of arguments. got=0, want=1")},
+		{`int2unichar(1,1)`, runtime.Errorf("wrong number of arguments. got=2, want=1")},
+		{`int2unichar("wrong")`, runtime.Errorf("string arguments not supported")},
+		{`int2unichar(-1)`, runtime.Errorf("value must be grater or equal to 0")},
+		{`int2unichar(2147483648)`, runtime.Errorf("value must be less than 2147483647")},
+		{`int2unichar(9786)`, runtime.NewUniversalString("☺")},
+	}
+
+	for _, tt := range tests {
+
+		val := testEval(t, tt.input)
+
+		switch expected := tt.expected.(type) {
+		case *runtime.Error:
+			err, ok := val.(*runtime.Error)
+			if !ok {
+				t.Errorf("object is not runtime.Error. got=%T (%+v)", val, val)
+				continue
+			}
+			if err.Error() != expected.Error() {
+				t.Errorf("wrong error message. got=%q, want=%s", err.Error(), expected.Error())
+			}
+		case *runtime.UniversalString:
+			if !expected.Equal(val) {
+				t.Errorf("wrong runtime.String. got=%v, want=%v", val, expected)
+			}
+		default:
+			t.Errorf("test error, unhandeled type:%T", expected)
+		}
+	}
+}
+
+func TestBuiltinFunctionUnichar2int(t *testing.T) {
+
+	tests := []struct {
+		input    string
+		expected runtime.Object
+	}{
+		{`unichar2int()`, runtime.Errorf("wrong number of arguments. got=0, want=1")},
+		{`unichar2int(1,1)`, runtime.Errorf("wrong number of arguments. got=2, want=1")},
+		{`unichar2int(1)`, runtime.Errorf("integer arguments not supported")},
+		{`unichar2int("to long")`, runtime.Errorf("argument must be of lenght=1")},
+		{`unichar2int("t")`, runtime.NewInt("116")},
+		{`unichar2int("☺")`, runtime.NewInt("9786")},
+	}
+
+	for _, tt := range tests {
+
+		val := testEval(t, tt.input)
+
+		switch expected := tt.expected.(type) {
+		case *runtime.Error:
+			err, ok := val.(*runtime.Error)
+			if !ok {
+				t.Errorf("object is not runtime.Error. got=%T (%+v)", val, val)
+				continue
+			}
+			if err.Error() != expected.Error() {
+				t.Errorf("wrong error message. got=%q, want=%s", err.Error(), expected.Error())
+				continue
+			}
+		case runtime.Int:
+			if !expected.Equal(val) {
+				t.Errorf("wrong runtime.String. got=%v, want=%v", val, expected)
+				continue
+			}
+		default:
+			t.Errorf("test error, unhandeled type:%T", expected)
+		}
+	}
+}

--- a/runtime/object.go
+++ b/runtime/object.go
@@ -33,6 +33,7 @@ const (
 	BOOL         ObjectType = "boolean"
 	STRING       ObjectType = "string"
 	BITSTRING    ObjectType = "bitstring"
+	UNISTRING    ObjectType = "universal string"
 	FUNCTION     ObjectType = "function"
 	LIST         ObjectType = "list"
 	RECORD       ObjectType = "record"
@@ -219,6 +220,37 @@ func (s *String) Get(index int) Object {
 
 func NewString(s string) *String {
 	return &String{Value: []rune(s)}
+}
+
+type UniversalString struct {
+	String string
+}
+
+func (us *UniversalString) Type() ObjectType { return UNISTRING }
+func (us *UniversalString) Inspect() string  { return us.String }
+func (us *UniversalString) Equal(obj Object) bool {
+	if other, ok := obj.(*UniversalString); ok {
+		return us.String == other.String
+	}
+	return false
+}
+func (us *UniversalString) hashKey() hashKey {
+	h := fnv.New64a()
+	h.Write([]byte(us.String))
+	return hashKey{Type: us.Type(), Value: h.Sum64()}
+}
+func (us *UniversalString) Len() int {
+	return len(us.String)
+}
+
+func (us *UniversalString) Get(index int) Object {
+	if index >= len(us.String) {
+		return &UniversalString{String: ""}
+	}
+	return &UniversalString{String: string(us.String[index])}
+}
+func NewUniversalString(s string) *UniversalString {
+	return &UniversalString{String: s}
 }
 
 type Bitstring struct {


### PR DESCRIPTION
I'm trying to implement two new build-in functions:

**there is an issue: both should use 'unversal charstring' which does not exist! there is no **runtime.UniCharstring****
Please provide some ideas on how to progress with this commit.

unichar2int

> C.1.12 Universal character to integer
>  unichar2int(in universal charstring invalue) return integer
> This function converts a single-character-length universal charstring value into an integer value in the range of
> 0 to 2 147 483 647. The integer value describes the 32-bit encoding of the character.
> In addition to the general error causes in clause 16.1.2, error causes are:
> • length of invalue does not equal 1. 

int2unichar

> C.1.2 Integer to universal character
>  int2unichar(in integer invalue) return universal charstring
> This function converts an integer value in the range of 0 to 2 147 483 647 (32-bit encoding) into a
> single-character-length universal charstring value. The integer value describes the 32-bit encoding of the
> character.
> In addition to the general error causes in clause 16.1.2, error causes are:
> • invalue is less than 0 or greater than 2147483647.