### PR TITLE
Add int2str builtin function

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -33,6 +33,20 @@ func Rnd(args ...runtime.Object) runtime.Object {
 	return runtime.Float(rand.Float64())
 }
 
+func Int2str(args ...runtime.Object) runtime.Object {
+	if len(args) != 1 {
+		return runtime.Errorf("wrong number of arguments. got=%d, want=1", len(args))
+	}
+	number, ok := args[0].(runtime.Int)
+	if !ok {
+		return runtime.Errorf("%s arguments not supported", args[0].Type())
+	}
+	if !number.IsInt64() {
+		return runtime.Errorf("Provided argument is not 64bit-integer")
+	}
+	return &runtime.String{Value: []rune(fmt.Sprintf("%d", number.Int64()))}
+}
+
 func Int2char(args ...runtime.Object) runtime.Object {
 	if len(args) != 1 {
 		return runtime.Errorf("wrong number of arguments. got=%d, want=1", len(args))
@@ -185,6 +199,7 @@ func makeSet(lt runtime.ListType, args ...runtime.Object) func(...runtime.Object
 func init() {
 	runtime.AddBuiltin("lengthof", Lengthof)
 	runtime.AddBuiltin("rnd", Rnd)
+	runtime.AddBuiltin("int2str", Int2str)
 	runtime.AddBuiltin("int2bit", Int2Bit)
 	runtime.AddBuiltin("int2float", Int2Float)
 	runtime.AddBuiltin("float2int", Float2Int)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -465,6 +465,46 @@ func testBool(t *testing.T, obj runtime.Object, expected bool) bool {
 	return true
 }
 
+func TestBuiltinFunctionInt2str(t *testing.T) {
+
+	tests := []struct {
+		input    string
+		expected runtime.Object
+	}{
+		{`int2str(2, 4)`, runtime.Errorf("wrong number of arguments. got=2, want=1")},
+		{`int2str("wrong")`, runtime.Errorf("string arguments not supported")},
+		{`int2str(2.4)`, runtime.Errorf("float arguments not supported")},
+		{`int2str(9223372036854775808)`, runtime.Errorf("Provided argument is not 64bit-integer")},
+		{`int2str(9223372036854775807)`, runtime.NewString("9223372036854775807")},
+		{`int2str(0)`, runtime.NewString("0")},
+		{`int2str(-9223372036854775808)`, runtime.NewString("-9223372036854775808")},
+		{`int2str(-9223372036854775809)`, runtime.Errorf("Provided argument is not 64bit-integer")},
+	}
+
+	for _, tt := range tests {
+
+		val := testEval(t, tt.input)
+
+		switch expected := tt.expected.(type) {
+		case *runtime.Error:
+			err, ok := val.(*runtime.Error)
+			if !ok {
+				t.Errorf("object is not runtime.Error. got=%T (%+v)", val, val)
+				continue
+			}
+			if err.Error() != expected.Error() {
+				t.Errorf("wrong error message. got=%s, want=%s", err.Error(), expected.Error())
+			}
+		case *runtime.String:
+			if !expected.Equal(val) {
+				t.Errorf("wrong runtime.String. got=%v, want=%v", val, expected)
+			}
+		default:
+			t.Errorf("test error, unhandeled type:%T", expected)
+		}
+	}
+}
+
 func TestBuiltinFunctionInt2char(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
Adding **int2str**

C.1.7 Integer to charstring
int2str(in integer invalue) return charstring
This function converts the integer value into its string equivalent (the base of the return string is always decimal).

The general error causes in clause 16.1.2 apply.
EXAMPLE:
int2str(66) // will return the charstring value "66"
int2str(-66) // will return the charstring value "-66"
int2str(0) // will return the charstring value "0" 