### PR TITLE
Fix indentation issues

### DIFF
--- a/ttcn3/v2/printer/printer_test.go
+++ b/ttcn3/v2/printer/printer_test.go
@@ -50,12 +50,16 @@ func TestSimpleFormatter(t *testing.T) {
 		{input: "control \n{}", want: "control\n{}"},
 		{input: "control\n {}", want: "control\n{}"},
 
-		// Verify that {,[ and ( increment the indentation level
+		// Verify that {, [ and ( increment the indentation level
 		{input: "{foo", want: "{foo"},
 		{input: "{\nfoo", want: "{\n\tfoo"},
 		{input: "{\n foo", want: "{\n\tfoo"},
 		{input: "{\nfoo}\nbar", want: "{\n\tfoo}\nbar"},
 		{input: "{\n[\n(\n1,2\n)\n]\n}", want: "{\n\t[\n\t\t(\n\t\t\t1,2\n\t\t)\n\t]\n}"},
+
+		// Verify that tokens with newlines have correct indentation
+		{input: "{// Foo\nBar", want: "{// Foo\n\tBar"},               //  Bar must be indented.
+		{input: "{\n/*\n* foo\n*/", want: "{\n\t/*\n\t * foo\n\t */"}, //  Comment must be indented, with one extra space.
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR fixes following indentation issues:

Indentation handling (p.needIndent) does not work for tokens contains
newlines (e.g. preprocessor directories and comments), causing the
following tokens have to no indentation at all.

Only the first line of multi-line comments (/* foobar */) was indented
correctly, because the comment string was printed verbatim. By printing
one comment line at a time (plus one space to align the asterisks), the
indentation is as excepted.

There are known scenarios where formatting is messed up. For example:

```ttcn3
	x := 1;        // foo
	y := 2;        // bar
	z := 345678;   /*
		        * blubb
		        */
```

The last two lines won't be aligned, but have the same indentation as
the `z` token.