### PR TITLE
Fix and modify Inspect behaviour

### DIFF
--- a/ttcn3/v2/syntax/syntax.go
+++ b/ttcn3/v2/syntax/syntax.go
@@ -187,7 +187,7 @@ func (n Node) FirstChild() Node {
 func (n Node) Next() Node {
 	switch te := n.event(); te.Type() {
 	case OpenNode:
-		if i := te.skip() + 1; i < len(n.tree.events) && n.tree.events[i].Type() != CloseNode {
+		if i := n.idx + te.skip() + 1; i < len(n.tree.events) && n.tree.events[i].Type() != CloseNode {
 			return n.get(i)
 		}
 		return Nil
@@ -204,7 +204,7 @@ func (n Node) Next() Node {
 }
 
 // Inspect traverses the syntax tree in depth-first order. It calls f for each
-// node recursively followed by a call of f(Nil).
+// node recursively. If n is a non-terminal the call is followed by a call of f(Nil).
 func (n Node) Inspect(f func(n Node) bool) {
 	if !f(n) {
 		return
@@ -212,7 +212,9 @@ func (n Node) Inspect(f func(n Node) bool) {
 	for c := n.FirstChild(); c != Nil; c = c.Next() {
 		c.Inspect(f)
 	}
-	f(Nil)
+	if n.IsNonTerminal() {
+		f(Nil)
+	}
 }
 
 // Pos returns the position (offset) of the node in the source code. Or -1 if


### PR DESCRIPTION
This PR fixes an endless loop of Inspect. `Next` function was using absolute event addressing, while Builder used relative event addressing.

This commit also changes the behaviour of Inspect: Calls to token will no longer be followed by a call to Nil.

Example: Tree this three nodes. Node A as root, with two children B and C. Previously Inspect executed these calls:

	f(A)
	f(B)
	f(Nil
	f(C)
	f(Nil)
	f(Nil)

Now, f(Nil) as only called after non-terminals:

	f(A)
	f(B)
	f(C)
	f(Nil)