### PR TITLE
Add new printer interface

### DIFF
--- a/format.go
+++ b/format.go
@@ -79,12 +79,14 @@ this tool. Do not use it in production yet.
 
 	listFiles, diff, inplace bool
 	formattedFiles           int
+	spaces                   int
 )
 
 func init() {
 	FormatCommand.Flags().BoolVarP(&inplace, "in-place", "i", false, "format files in place")
 	FormatCommand.Flags().BoolVarP(&diff, "diff", "d", false, "display diff instead of rewriting files. Exit with non-zero status if any files need to be formatted")
 	FormatCommand.Flags().BoolVarP(&listFiles, "list", "l", false, "list files whose formatting differs. Exit with non-zero status if any files need to be formatted")
+	FormatCommand.Flags().IntVarP(&spaces, "tabs-to-spaces", "s", 0, "convert each tab to N spaces")
 }
 
 func processFile(path string) error {
@@ -94,7 +96,13 @@ func processFile(path string) error {
 	}
 
 	var buf bytes.Buffer
-	if err := printer.Fprint(&buf, src); err != nil {
+	p := printer.NewCanonicalPrinter(&buf)
+	p.Indent = -1
+	if spaces > 0 {
+		p.UseSpaces = true
+		p.TabWidth = spaces
+	}
+	if err := p.Fprint(src); err != nil {
 		return err
 	}
 	res := buf.Bytes()

--- a/internal/lsp/formatter.go
+++ b/internal/lsp/formatter.go
@@ -3,7 +3,6 @@ package lsp
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/nokia/ntt/internal/fs"
 	"github.com/nokia/ntt/internal/loc"
@@ -20,9 +19,14 @@ func (s *Server) formatting(ctx context.Context, params *protocol.DocumentFormat
 	}
 	var out bytes.Buffer
 	p := printer.NewCanonicalPrinter(&out)
+	p.TabWidth = int(params.Options.TabSize)
 	if params.Options.InsertSpaces {
-		p.Indent = fmt.Sprintf("%*s", params.Options.TabSize, " ")
+		p.UseSpaces = true
 	}
+
+	// We don't want module defintions to be indented. By using a negative
+	// indentation level we can achieve this for most module definitions.
+	p.Indent = -1
 
 	if err := p.Fprint(b); err != nil {
 		log.Debug("formatting:", err.Error())

--- a/ttcn3/v2/printer/example_test.go
+++ b/ttcn3/v2/printer/example_test.go
@@ -21,11 +21,13 @@ func ExampleFprint() {
 func ExampleCanonicalPrinter() {
 	input := "{\n x:=1, // Comment\ny := 234, // Comment 2\n}"
 	p := printer.NewCanonicalPrinter(os.Stdout)
-	p.Indent = "  "
+	p.Indent = 1
+	p.UseSpaces = true
+	p.TabWidth = 2
 	p.Fprint(input)
 	// Output:
-	// {
-	//   x := 1,   // Comment
-	//   y := 234, // Comment 2
-	// }
+	//   {
+	//     x := 1,   // Comment
+	//     y := 234, // Comment 2
+	//   }
 }


### PR DESCRIPTION
This commit introduces a printer interface which makes it easier switch between tabs or spaces.

The format command now has a new option --tabs-to-spaces=N which will convert tabs to N spaces, if specified.

Additionally we start at indentation level -1, which is a hack to prevent module definitions being indented.