### PR TITLE
Revert test to match the old k3r behavior.

### DIFF
--- a/k3/k3r/k3r_test.go
+++ b/k3/k3r/k3r_test.go
@@ -69,7 +69,7 @@ func TestEvents(t *testing.T) {
 		{
 			input: "test3.test3",
 			events: []string{
-				"ErrorEvent error (no such test case)",
+				"ErrorEvent error (exit status 2)",
 			}},
 		{
 			input: "asd",


### PR DESCRIPTION
This commit revert a test to match the old k3r version.

The test in question had been aligned with a new k3r version, which has not been released yet. Causing local tests to fail.

Until the new k3r version is released, we revert the test to match the old behavior.