### PR TITLE
Check arguments when calling builtin functions

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -94,7 +94,10 @@ func Int2Enum(args ...runtime.Object) runtime.Object {
 	if !ok {
 		return runtime.Errorf("second argument must be an enum value")
 	}
-	return e.SetValueById(int(i.Int64()))
+	if err := e.SetValueById(int(i.Int64())); err != nil {
+		return err
+	}
+	return nil
 }
 
 func Log(args ...runtime.Object) runtime.Object {

--- a/runtime/builtins.go
+++ b/runtime/builtins.go
@@ -1,7 +1,99 @@
 package runtime
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/nokia/ntt/ttcn3"
+	"github.com/nokia/ntt/ttcn3/ast"
+)
+
 var builtins = map[string]*Builtin{}
 
-func AddBuiltin(name string, f func(args ...Object) Object) {
-	builtins[name] = &Builtin{Fn: f}
+// AddBuiltin adds a builtin function to the runtime environment.
+//
+// An error is returned if the builtin-name is already registered.
+//
+// If the given identifier provides formal parameters, the function will be
+// checked for the correct number and type of arguments, automatically. An
+// error is returnes if the input string contrains any syntax-errors.
+func AddBuiltin(id string, fn func(args ...Object) Object) *Error {
+	if i := strings.Index(id, "("); i >= 0 {
+		name, params, err := parseFunction(id)
+		if err != nil {
+			return Errorf("%w", err)
+		}
+		origFn := fn
+		fn = func(args ...Object) Object {
+			if err := checkArgs(params, args...); err != nil {
+				return Errorf("%w", err)
+			}
+			return origFn(args...)
+		}
+		id = name
+	}
+	if _, ok := builtins[id]; ok {
+		return Errorf("%s already defined", id)
+	}
+	builtins[id] = &Builtin{Fn: fn}
+	return nil
+}
+
+func parseFunction(name string) (string, *ast.FormalPars, error) {
+	tree := ttcn3.Parse("function " + name + ";")
+	if tree.Err != nil {
+		return "", nil, tree.Err
+	}
+	funcs := tree.Funcs()
+	if len(funcs) != 1 {
+		return "", nil, errors.New("invalid signature")
+	}
+	return ast.Name(funcs[0].Node), funcs[0].Node.(*ast.FuncDecl).Params, nil
+}
+
+func checkArgs(pars *ast.FormalPars, args ...Object) error {
+	if len(args) != len(pars.List) {
+		return fmt.Errorf("wrong number of arguments. got=%d, want=%d", len(args), len(pars.List))
+	}
+	for i := range args {
+		if err := checkArg(pars.List[i], args[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkArg(par *ast.FormalPar, arg Object) error {
+	if par.ArrayDef != nil {
+		return fmt.Errorf("array parameters not supported")
+	}
+
+	// We only support the basic types for now. No typedefs, no records, no
+	// templates, ...
+	types := map[string]ObjectType{
+		"integer":              INTEGER,
+		"boolean":              BOOL,
+		"float":                FLOAT,
+		"bitstring":            BITSTRING,
+		"hexstring":            BITSTRING,
+		"octetstring":          BITSTRING,
+		"charstring":           STRING,
+		"universal charstring": STRING,
+		"verdicttype":          VERDICT,
+		"any":                  ANY,
+	}
+
+	want := ast.Name(par.Type)
+	switch types[want] {
+	case UNKNOWN:
+		return fmt.Errorf("unsupported parameter type: %s", want)
+	case ANY:
+		return nil
+	default:
+		if types[want] == arg.Type() {
+			return nil
+		}
+		return fmt.Errorf("%s arguments not supported", string(arg.Type()))
+	}
 }

--- a/ttcn3/parser/parser.go
+++ b/ttcn3/parser/parser.go
@@ -766,12 +766,7 @@ func (p *parser) parseOperand() ast.Expr {
 			}
 		}
 
-		// Workaround for deprecated port-attribute 'all'
-		if tok.Kind == token.ALL {
-			return p.make_use(tok)
-		}
-
-		p.errorExpected(p.pos(1), "'component', 'port', 'timer' or 'from'")
+		return p.make_use(tok)
 
 	case token.UNIVERSAL:
 		return p.parseUniversalCharstring()


### PR DESCRIPTION
Until we have proper semantic analysis, we need to check the arguments of builtin functions explicitly. This commit allows us to specify formal parameters for builtin functions. When formal parameters are available, the function arguments will be checked against them.

This initial implementation is only rudimentary.

Additional changes:
* the new functionality to the existing builtins.
* update tests for handle modified error messages.
* allow integers in `runtime.NewInt`.
* add support for `any` type.