### PR TITLE
Add builtin function str2int

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -3,6 +3,7 @@ package builtins
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 
 	"github.com/nokia/ntt/runtime"
@@ -32,6 +33,15 @@ func Int2Char(args ...runtime.Object) runtime.Object {
 		return runtime.NewCharstring(string(rune(i)))
 	}
 	return runtime.Errorf("Argument is out of range. Range is from 0 to 127. Int = %s", n.String())
+}
+
+func Str2Int(args ...runtime.Object) runtime.Object {
+	s := args[0].(*runtime.String)
+	i, err := strconv.Atoi(s.String())
+	if err != nil {
+		return runtime.Errorf("invalid syntax: %s", s.String())
+	}
+	return runtime.NewInt(i)
 }
 
 func Int2Unichar(args ...runtime.Object) runtime.Object {
@@ -136,6 +146,7 @@ func init() {
 		"int2enum(in integer i, out any e)":                     Int2Enum,
 		"int2float(in integer i) return float":                  Int2Float,
 		"int2str(in integer i) return charstring":               Int2Str,
+		"str2int(in charstring s) return integer":               Str2Int,
 		"int2unichar(in integer i) return universal charstring": Int2Unichar,
 		"lengthof(in any a) return integer":                     Lengthof,
 		"rnd() return float":                                    Rnd,

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -291,6 +291,11 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`int2char(0)`, runtime.NewCharstring(fmt.Sprintf("%c", 0))},
 		{`int2char(127)`, runtime.NewCharstring(fmt.Sprintf("%c", 127))},
 
+		{`str2int("wrong")`, runtime.Errorf("invalid syntax: wrong")},
+		{`str2int("2-3")`, runtime.Errorf("invalid syntax: 2-3")},
+		{`str2int("150")`, runtime.NewInt("150")},
+		{`str2int("-150")`, runtime.NewInt("-150")},
+
 		{`type enumerated E1 {red, green, blue}; var E1 testVar := blue; int2enum(0, testVar); testVar`, `E1.red`},
 		{`type enumerated E1{red(10), green(0), blue(1)}; var E1 testVar := blue; int2enum(10, testVar); testVar`, `E1.red`},
 		{`type enumerated E1 {red(10..20), green, blue}; var E1 testVar := blue; int2enum(11, testVar); testVar`, `E1.red`},


### PR DESCRIPTION
This function converts a charstring representing an integer value to the equivalent integer.
In addition to the general error causes in clause 16.1.2, error causes are:
• invalue contains characters other than "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" and "-".
• invalue contains the character "-" at another position than the leftmost one.

EXAMPLE:
str2int("66") // will return the integer value 66
str2int("-66") // will return the integer value -66
str2int("6-6") // will cause an erro