### PR TITLE
Add builtin function str2float

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -44,6 +44,16 @@ func Str2Int(args ...runtime.Object) runtime.Object {
 	return runtime.NewInt(i)
 }
 
+func Str2Float(args ...runtime.Object) runtime.Object {
+	s := args[0].(*runtime.String)
+
+	_, err := strconv.ParseFloat(s.String(), 64)
+	if err != nil {
+		return runtime.Errorf("invalid syntax: %s", s.String())
+	}
+	return runtime.NewFloat(s.String())
+}
+
 func Int2Unichar(args ...runtime.Object) runtime.Object {
 	n := args[0].(runtime.Int)
 	if i := n.Uint64(); n.IsUint64() && i <= 2147483647 {
@@ -147,6 +157,7 @@ func init() {
 		"int2float(in integer i) return float":                  Int2Float,
 		"int2str(in integer i) return charstring":               Int2Str,
 		"str2int(in charstring s) return integer":               Str2Int,
+		"str2float(in charstring s) return float":               Str2Float,
 		"int2unichar(in integer i) return universal charstring": Int2Unichar,
 		"lengthof(in any a) return integer":                     Lengthof,
 		"rnd() return float":                                    Rnd,

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -296,6 +296,11 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`str2int("150")`, runtime.NewInt("150")},
 		{`str2int("-150")`, runtime.NewInt("-150")},
 
+		{`str2float("wrong")`, runtime.Errorf("invalid syntax: wrong")},
+		{`str2float("2-3")`, runtime.Errorf("invalid syntax: 2-3")},
+		{`str2float("150")`, runtime.NewFloat("150")},
+		{`str2float("-150")`, runtime.NewFloat("-150")},
+
 		{`type enumerated E1 {red, green, blue}; var E1 testVar := blue; int2enum(0, testVar); testVar`, `E1.red`},
 		{`type enumerated E1{red(10), green(0), blue(1)}; var E1 testVar := blue; int2enum(10, testVar); testVar`, `E1.red`},
 		{`type enumerated E1 {red(10..20), green, blue}; var E1 testVar := blue; int2enum(11, testVar); testVar`, `E1.red`},


### PR DESCRIPTION
This function converts a charstring comprising a number into a float value. The format of the number in the
charstring shall follow rules in clause 6.1.0, items a) or b) with the following exceptions:
• leading zeros are allowed;
• leading "+" sign before positive values is allowed;
• "-0.0" is allowed;
• no numbers after the dot in the decimal notation are allowed.
In addition to the general error causes in clause 16.1.2, error causes are:
• the format of invalue is different than defined above.

EXAMPLE:
str2float("12345.6") // is the same as str2float("123.456E+02")
str2float("1.6") // returns a float value equal to 1.