### PR TITLE
Add builtin function enum2int

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -120,6 +120,25 @@ func Int2Enum(args ...runtime.Object) runtime.Object {
 	return nil
 }
 
+func Enum2Int(args ...runtime.Object) runtime.Object {
+	e, ok := args[0].(*runtime.EnumValue)
+	if !ok {
+		return runtime.Errorf("Argument must be an enum value")
+	}
+
+	ranges, err := e.ReturnIdByValue()
+	if err != nil {
+		return runtime.Errorf("Can't find ID of provided value")
+	}
+	smallestId := 0
+	for i, enumRange := range ranges {
+		if enumRange.First < smallestId || i == 0 {
+			smallestId = enumRange.First
+		}
+	}
+	return runtime.NewInt(smallestId)
+}
+
 func Log(args ...runtime.Object) runtime.Object {
 	var ss []string
 	for _, arg := range args {
@@ -154,6 +173,7 @@ func init() {
 		"int2bit(in integer i, in integer l) return bitstring":  Int2Bit,
 		"int2char(in integer i) return charstring":              Int2Char,
 		"int2enum(in integer i, out any e)":                     Int2Enum,
+		"enum2int(in any e) return integer":                     Enum2Int,
 		"int2float(in integer i) return float":                  Int2Float,
 		"int2str(in integer i) return charstring":               Int2Str,
 		"str2int(in charstring s) return integer":               Str2Int,

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -308,6 +308,10 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`type enumerated E1 {red, green, blue}; var E1 testVar := blue; int2enum(0, "wrong")`, runtime.Errorf("second argument must be an enum value")},
 		{`type enumerated E1 {red, green, blue}; var E1 testVar := blue; int2enum(4, testVar)`, runtime.Errorf("id 4 does not exist in any ranges of Enum E1")},
 
+		{`type enumerated E1 {red, green, blue}; var E1 testVar := blue; enum2int(testVar);`, `2`},
+		{`type enumerated E1 {red, green, blue}; var E1 testVar := blue; enum2int("wrong")`, runtime.Errorf("Argument must be an enum value")},
+		{`type enumerated E1 {red(10..20), green, blue}; var E1 testVar := red; enum2int(testVar);`, `10`},
+
 		{`int2unichar(-1)`, runtime.Errorf("Argument is out of range. Range is from 0 to 2147483647. Int = -1")},
 		{`int2unichar(2147483648)`, runtime.Errorf("Argument is out of range. Range is from 0 to 2147483647. Int = 2147483648")},
 		{`int2unichar(9786)`, runtime.NewUniversalString("☺")},

--- a/runtime/object.go
+++ b/runtime/object.go
@@ -283,6 +283,14 @@ func (ev *EnumValue) SetValueById(id int) *Error {
 	}
 	return Errorf("id %d does not exist in any ranges of Enum %s", id, ev.typeRef.Name)
 }
+
+func (ev *EnumValue) ReturnIdByValue() ([]EnumRange, *Error) {
+	ranges, ok := ev.typeRef.Elements[ev.key]
+	if !ok {
+		return []EnumRange{}, Errorf("%s does not exist in Enum %s", ev.key, ev.typeRef.Name)
+	}
+	return ranges, nil
+}
 func NewEnumValue(enumType *EnumType, key string) (*EnumValue, error) {
 	if _, ok := enumType.Elements[key]; !ok {
 		return nil, fmt.Errorf("%s does not exist in Enum %s", key, enumType.Name)


### PR DESCRIPTION
enum2int(in Enumerated_type inpar) return integer

This function accepts an enumerated value and returns the integer value associated to the enumerated value. The actual parameter passed to inpar always shall be a typed object.

    type enumerated MyFirstEnumType {
        Monday, Tuesday, Wednesday, Thursday, Friday
    };
    type enumerated MySecondEnumType {
        Saturday(-3), Sunday (0), Monday
    };

    //within a dynamic language element:
    var MyFirstEnumType vl_FirstEnum := Monday;
    var MySecondEnumType vl_SecondEnum := Monday;
    enum2int(vl_FirstEnum) // returns 0
    enum2int(vl_SecondEnum) // returns 1