### PR TITLE
Add LogEvent

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,6 +189,9 @@ func fatal(err error) {
 	switch err := err.(type) {
 	case *exec.ExitError:
 		waitStatus := err.Sys().(syscall.WaitStatus)
+		if waitStatus.ExitStatus() == -1 {
+			errors.PrintError(os.Stderr, err)
+		}
 		os.Exit(waitStatus.ExitStatus())
 	case errors.ErrorList:
 		errors.PrintError(os.Stderr, err)

--- a/run.go
+++ b/run.go
@@ -138,6 +138,8 @@ func runTests(cmd *cobra.Command, args []string) error {
 		log.Debugf("result: event=%#v\n", e)
 
 		switch e := e.(type) {
+		case tests.LogEvent:
+			log.Debugln(e.Text)
 
 		case tests.StartEvent:
 			running[e.Job] = e.Time()

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -71,6 +71,17 @@ func NewErrorEvent(err error) ErrorEvent {
 	return ErrorEvent{event{t: time.Now()}, err}
 }
 
+// LogEvent is an event that provided additional information about the test execution.
+type LogEvent struct {
+	Text string
+	event
+	*Job
+}
+
+func NewLogEvent(job *Job, text string) LogEvent {
+	return LogEvent{event: event{t: time.Now()}, Job: job, Text: text}
+}
+
 // StartEvent is an event that is emitted when the test is started.
 type StartEvent struct {
 	Name string
@@ -119,6 +130,8 @@ func UnwrapJob(e Event) *Job {
 	case StartEvent:
 		return e.Job
 	case StopEvent:
+		return e.Job
+	case LogEvent:
 		return e.Job
 	case ErrorEvent:
 		var err *JobError


### PR DESCRIPTION
k3r stderr messages are forwarded to ntt run as debug messages.