### PR TITLE
Fix unexpected characters in hover output

### DIFF
--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -54,18 +54,18 @@ func getSignature(def *ttcn3.Node) string {
 	switch node := def.Node.(type) {
 	case *syntax.FuncDecl:
 		sig.WriteString(node.Kind.String() + " " + node.Name.String())
-		sig.Write(content[node.Params.Pos()-1 : node.Params.End()])
+		sig.Write(content[node.Params.Pos() : node.Params.End()])
 		if node.RunsOn != nil {
 			sig.WriteString("\n  ")
-			sig.Write(content[node.RunsOn.Pos()-1 : node.RunsOn.End()])
+			sig.Write(content[node.RunsOn.Pos() : node.RunsOn.End()])
 		}
 		if node.System != nil {
 			sig.WriteString("\n  ")
-			sig.Write(content[node.System.Pos()-1 : node.System.End()])
+			sig.Write(content[node.System.Pos() : node.System.End()])
 		}
 		if node.Return != nil {
 			sig.WriteString("\n  ")
-			sig.Write(content[node.Return.Pos()-1 : node.Return.End()])
+			sig.Write(content[node.Return.Pos() : node.Return.End()])
 		}
 	case *syntax.ValueDecl, *syntax.TemplateDecl, *syntax.FormalPar, *syntax.StructTypeDecl, *syntax.ComponentTypeDecl, *syntax.EnumTypeDecl, *syntax.PortTypeDecl:
 		sig.Write(content[def.Node.Pos()-1 : def.Node.End()])

--- a/internal/lsp/hover_test.go
+++ b/internal/lsp/hover_test.go
@@ -1,0 +1,84 @@
+package lsp_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nokia/ntt/internal/fs"
+	"github.com/nokia/ntt/internal/lsp"
+	"github.com/nokia/ntt/internal/lsp/protocol"
+	"github.com/nokia/ntt/ttcn3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlainTextHoverForFunction(t *testing.T) {
+	actual := testHover(t, `
+        module Test {
+            function myfunc(integer x)
+                runs on Component
+                system System
+                return integer
+            {
+                return x;
+            }
+        }`,
+		protocol.Position{Line: 2, Character: 25},
+		&lsp.PlainTextHover{})
+
+	expected :=
+		"function myfuncc(integer x)\n" +
+			"   runs on Component\n" +
+			"   system System\n" +
+			"   return integer\n"
+
+	assert.Equal(t, expected, actual.Contents.Value)
+}
+
+func TestMarkdownHoverForFunction(t *testing.T) {
+	actual := testHover(t, `
+        module Test {
+            function myfunc(integer x)
+                runs on Component
+                system System
+                return integer
+            {
+                return x;
+            }
+        }`,
+		protocol.Position{Line: 2, Character: 25},
+		&lsp.MarkdownHover{})
+
+	expected :=
+		"```typescript\n" +
+			"function myfuncc(integer x)\n" +
+			"   runs on Component\n" +
+			"   system System\n" +
+			"   return integer\n" +
+			"```\n" +
+			" - - -\n" +
+			"\n" +
+			" - - -\n"
+
+	assert.Equal(t, expected, actual.Contents.Value)
+}
+
+func testHover(t *testing.T, text string, position protocol.Position, capability lsp.HoverContentProvider) *protocol.Hover {
+	t.Helper()
+
+	file := fmt.Sprintf("%s.ttcn3", t.Name())
+	fs.SetContent(file, []byte(text))
+
+	params := protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			Position: position,
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: protocol.DocumentURI(file),
+			},
+		},
+	}
+
+	hover, err := lsp.ProcessHover(&params, &ttcn3.DB{}, capability)
+	assert.Equal(t, err, nil)
+
+	return hover
+}

--- a/internal/lsp/hover_test.go
+++ b/internal/lsp/hover_test.go
@@ -26,10 +26,10 @@ func TestPlainTextHoverForFunction(t *testing.T) {
 		&lsp.PlainTextHover{})
 
 	expected :=
-		"function myfuncc(integer x)\n" +
-			"   runs on Component\n" +
-			"   system System\n" +
-			"   return integer\n"
+		"function myfunc(integer x)\n" +
+			"  runs on Component\n" +
+			"  system System\n" +
+			"  return integer\n"
 
 	assert.Equal(t, expected, actual.Contents.Value)
 }
@@ -50,10 +50,10 @@ func TestMarkdownHoverForFunction(t *testing.T) {
 
 	expected :=
 		"```typescript\n" +
-			"function myfuncc(integer x)\n" +
-			"   runs on Component\n" +
-			"   system System\n" +
-			"   return integer\n" +
+			"function myfunc(integer x)\n" +
+			"  runs on Component\n" +
+			"  system System\n" +
+			"  return integer\n" +
 			"```\n" +
 			" - - -\n" +
 			"\n" +


### PR DESCRIPTION
This PR removes erroneous characters present in the textDocument/hover output for functions:
* repeated letter in function name,
* extra whitespace for indenting runs on/system/return clauses.