### PR TITLE
delete deprecated fields from .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,15 +38,9 @@ nfpms:
       - golang
 
     bindir: /usr/bin
-    replacements:
-      386: i386
-      amd64: x86_64
 
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
-    replacements:
-      386: i386
-      amd64: x86_64
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
The release procedure failed due to deprecated `replacements` field inside `.goreleaser.yml`