### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           mkdir -p build
           echo "executing: go-msi make --msi $PWD/ntt.msi --out $PWD/build --version ${GITHUB_REF#refs/tags/}"
           go-msi make --msi "$PWD/ntt.msi" --out "$PWD/build" --version "${GITHUB_REF#refs/tags/}"
-          printf "::set-output name=msi::%s\n" *.msi
+          printf "msi=%s\n" *.msi >> "$GITHUB_OUTPUT"
       - name: Upload MSI
         run: |
           $env:PATH += ";C:\hub\bin"


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter