### PR TITLE
Support for dynamic templates

### DIFF
--- a/ttcn3/syntax/nodes.go
+++ b/ttcn3/syntax/nodes.go
@@ -314,6 +314,12 @@ type (
 		X      Expr  // Template expression
 	}
 
+	// A DynamicExpr represents a "@dynamic" expression.
+	DynamicExpr struct {
+		Tok  Token      // Position of "dynamic"
+		Body *BlockStmt // Template body
+	}
+
 	// A DefKindExpr represents a definition kind expression, used by imports
 	// and with-attributes.
 	DefKindExpr struct {
@@ -360,6 +366,7 @@ func (x *RegexpExpr) exprNode()        {}
 func (x *PatternExpr) exprNode()       {}
 func (x *DecmatchExpr) exprNode()      {}
 func (x *DecodedExpr) exprNode()       {}
+func (x *DynamicExpr) exprNode()       {}
 func (x *DefKindExpr) exprNode()       {}
 func (x *ExceptExpr) exprNode()        {}
 

--- a/ttcn3/syntax/nodes_gen.go
+++ b/ttcn3/syntax/nodes_gen.go
@@ -2090,6 +2090,73 @@ func (n *DoWhileStmt) End() int {
 	return -1
 }
 
+func (n *DynamicExpr) FirstTok() Token {
+	switch {
+
+	case n.Tok != nil:
+		return n.Tok
+
+	case n.Body != nil:
+		return n.Body.FirstTok()
+
+	default:
+		return nil
+	}
+}
+
+func (n *DynamicExpr) LastTok() Token {
+	switch {
+
+	case n.Body != nil:
+		return n.Body.LastTok()
+
+	case n.Tok != nil:
+		return n.Tok
+
+	default:
+		return nil
+	}
+}
+
+func (n *DynamicExpr) Children() []Node {
+	ret := make([]Node, 0, 2)
+
+	if n.Tok != nil {
+		ret = append(ret, n.Tok)
+	}
+
+	if n.Body != nil {
+		ret = append(ret, n.Body)
+	}
+
+	return ret
+}
+
+func (n *DynamicExpr) Inspect(f func(Node) bool) {
+
+	if c := n.Body; c != nil {
+		if f(c) {
+			c.Inspect(f)
+		}
+		f(nil)
+	}
+
+}
+
+func (n *DynamicExpr) Pos() int {
+	if tok := n.FirstTok(); tok != nil {
+		return tok.Pos()
+	}
+	return -1
+}
+
+func (n *DynamicExpr) End() int {
+	if tok := n.LastTok(); tok != nil {
+		return tok.End()
+	}
+	return -1
+}
+
 func (n *EnumSpec) FirstTok() Token {
 	switch {
 

--- a/ttcn3/syntax/parser.go
+++ b/ttcn3/syntax/parser.go
@@ -817,7 +817,10 @@ func (p *parser) parseOperand() Expr {
 		return p.parseCallDecmatch()
 
 	case MODIF:
-		return p.parseDecodedModifier()
+		return p.parseModifier()
+
+	case VALUE:
+		return p.parseIdent()
 
 	default:
 		p.errorExpected("operand")
@@ -897,6 +900,13 @@ func (p *parser) parseCallDecmatch() *DecmatchExpr {
 	return c
 }
 
+func (p *parser) parseModifier() Expr {
+	if p.peek(1).String() == "@dynamic" {
+		return p.parseDynamicModifier()
+	}
+	return p.parseDecodedModifier()
+}
+
 func (p *parser) parseDecodedModifier() *DecodedExpr {
 	d := new(DecodedExpr)
 	d.Tok = p.expect(MODIF)
@@ -908,6 +918,13 @@ func (p *parser) parseDecodedModifier() *DecodedExpr {
 		d.Params = p.parseParenExpr()
 	}
 	d.X = p.parsePrimaryExpr()
+	return d
+}
+
+func (p *parser) parseDynamicModifier() *DynamicExpr {
+	d := new(DynamicExpr)
+	d.Tok = p.expect(MODIF)
+	d.Body = p.parseBlockStmt()
 	return d
 }
 
@@ -1015,7 +1032,7 @@ func (p *parser) parseIdent() *Ident {
 	switch p.tok {
 	case UNIVERSAL:
 		return p.parseUniversalCharstring()
-	case IDENT, ADDRESS, ALIVE, CHARSTRING, CONTROL, TO, FROM, CREATE:
+	case IDENT, ADDRESS, ALIVE, CHARSTRING, CONTROL, TO, FROM, CREATE, VALUE:
 		return p.make_use(p.consume())
 	default:
 		p.expect(IDENT) // use expect() error handling


### PR DESCRIPTION
Currently, the following code cannot be parsed:
```
type enumerated Enumeration
{
    First,
    // ...
    Last
}

template Enumeration a_EnumerationRange(Enumeration first, Enumeration last) := @dynamic {
    return isWithin(enum2int(value), enum2int(first), enum2int(last));
}
```