### PR TITLE
Fix parsing of multiline string literals

### DIFF
--- a/ttcn3/syntax/scanner.go
+++ b/ttcn3/syntax/scanner.go
@@ -254,7 +254,6 @@ func (s *Scanner) scanString() Kind {
 		switch ch := s.src[s.pos]; ch {
 		case '\n', '\v', '\f':
 			s.lines = append(s.lines, s.pos+1)
-			s.pos++
 		case '\\':
 			s.pos++
 		case '"':

--- a/ttcn3/syntax/scanner_test.go
+++ b/ttcn3/syntax/scanner_test.go
@@ -23,6 +23,39 @@ func TestTokenize(t *testing.T) {
 			`COMMENT "//"`,
 			`EOF`,
 		}},
+		{`"str"
+				`, []string{
+			`STRING "\"str\""`,
+			`EOF`,
+		}},
+		{`"multiline
+str"
+`, []string{
+			`STRING "\"multiline\nstr\""`,
+			`EOF`,
+		}},
+		{`"
+multiline
+str"
+`, []string{
+			`STRING "\"\nmultiline\nstr\""`,
+			`EOF`,
+		}},
+		{`"multiline
+str
+"
+`, []string{
+			`STRING "\"multiline\nstr\n\""`,
+			`EOF`,
+		}},
+		{`"
+multiline
+str
+"
+`, []string{
+			`STRING "\"\nmultiline\nstr\n\""`,
+			`EOF`,
+		}},
 	}
 	for _, test := range tests {
 		root := Tokenize([]byte(test.input))


### PR DESCRIPTION
Currently, parsing a multiline string literal that ends with a single terminal quote on the last line results in an error:

```
foo := "multiline
string
literal
"
```