### PR TITLE
Revert "Ntt"

### DIFF
--- a/internal/lsp/span/parse.go
+++ b/internal/lsp/span/parse.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
-	"math"
 )
 
 // Parse returns the location represented by the input.
@@ -87,10 +86,8 @@ func rstripSuffix(input string) suffix {
 	if last >= 0 && last < len(remains)-1 {
 		number, err := strconv.ParseInt(remains[last+1:], 10, 64)
 		if err == nil {
-			if number >= math.MinInt && number <= math.MaxInt {
-				num = int(number)
-				remains = remains[:last+1]
-			}
+			num = int(number)
+			remains = remains[:last+1]
 		}
 	}
 	// now see if we have a trailing separator


### PR DESCRIPTION
Reverts nokia/ntt#767

Looks like it is useless and does not do anything actually and can actually do harm in some specific cases

Correct way is to set `ParseInt` `bitSize` param to `32`